### PR TITLE
fix - added source grid size reset in move constructor

### DIFF
--- a/grid/include/grid/grid.hpp
+++ b/grid/include/grid/grid.hpp
@@ -39,6 +39,8 @@ public:
     Grid(Grid<T> &&grid)
         : m_data(std::move(grid.m_data)), m_nbRows(grid.m_nbRows), m_nbCols(grid.m_nbCols)
     {
+        grid.m_nbRows = 0;
+        grid.m_nbCols = 0;
     }
 
     ~Grid()


### PR DESCRIPTION
# Fixes applied
- added source grid size reset in save constructor

# Test performed
## Line sequencing
Validate correct sequencing of 30 lines based on the levels #1-1 and #1-2 of the Nonogram Galaxy game
1. Invoke Ctest in the build folder
2. Validate tests success

TESTS DO NOT COMPILE DUE TO BUGS IN GRID CLASS; WILL BE FIXED IN NEXT BRANCH

# Test configuration
## Test hardwarte
- x86 machine
- Ryzen 5950x
- 32 GB of RAM
## Software
- Windows 10.0.19045
- GCC 12.2.0 x68_64-w64 mingw32
- cmake 3.23.2