### PR TITLE
fix - made padding value of resize method a const ref

### DIFF
--- a/grid/include/grid/grid.hpp
+++ b/grid/include/grid/grid.hpp
@@ -93,7 +93,7 @@ public:
         m_nbCols - nbCols;
     }
 
-    void resize(size_type nbRows, size_type nbCols, T &val)
+    void resize(size_type nbRows, size_type nbCols, const T &val)
     {
         std::vector<T> newArray(nbRows * nbCols, val);
 


### PR DESCRIPTION
# Fixes applied
- made padding value of resize method a const ref

# Test performed
## Line sequencing
Validate correct sequencing of 30 lines based on the levels #1-1 and #1-2 of the Nonogram Galaxy game
1. Invoke Ctest in the build folder
2. Validate tests success

TESTS DO NOT COMPILE DUE TO BUGS IN GRID CLASS; WILL BE FIXED IN NEXT BRANCH

# Test configuration
## Test hardwarte
- x86 machine
- Ryzen 5950x
- 32 GB of RAM
## Software
- Windows 10.0.19045
- GCC 12.2.0 x68_64-w64 mingw32
- cmake 3.23.2