### PR TITLE
Feat/grid template/extract non modifiable column

### DIFF
--- a/grid/include/grid/grid.hpp
+++ b/grid/include/grid/grid.hpp
@@ -248,16 +248,16 @@ public:
     	return colToReturn;
     }
 
-    // const std::vector<T> col(size_type col) const
-    // {
-    // 	std::vector<T> colToReturn(m_nbRows);
+    const std::vector<T> col(size_type col) const
+    {
+    	std::vector<T> colToReturn(m_nbRows);
 
-    // 	for (int i = 0; i < m_nbRows; ++i) {
-    // 		colToReturn[i] = m_data[i*m_nbCols + col];
-    // 	}
+    	for (int i = 0; i < m_nbRows; ++i) {
+    		colToReturn[i] = m_data[i*m_nbCols + col];
+    	}
 
-    // 	return colToReturn;
-    // }
+    	return colToReturn;
+    }
 
     // Grid<T> firstRowGrid()
     // {

--- a/grid/include/grid/grid.hpp
+++ b/grid/include/grid/grid.hpp
@@ -248,12 +248,14 @@ public:
     	return colToReturn;
     }
 
-    const std::vector<T> col(size_type col) const
+    const std::vector<std::reference_wrapper<const T>> col(size_type col) const
     {
-    	std::vector<T> colToReturn(m_nbRows);
+    	std::vector<std::reference_wrapper<T>>colToReturn;
+        colToReturn.reserve(m_nbRows);
 
     	for (int i = 0; i < m_nbRows; ++i) {
-    		colToReturn[i] = m_data[i*m_nbCols + col];
+    		colToReturn.push_back(
+                std::ref(this->at(i, col)));
     	}
 
     	return colToReturn;

--- a/grid/include/grid/grid.hpp
+++ b/grid/include/grid/grid.hpp
@@ -250,7 +250,7 @@ public:
 
     const std::vector<std::reference_wrapper<const T>> col(size_type col) const
     {
-    	std::vector<std::reference_wrapper<T>>colToReturn;
+    	std::vector<std::reference_wrapper<const T>>colToReturn;
         colToReturn.reserve(m_nbRows);
 
     	for (int i = 0; i < m_nbRows; ++i) {

--- a/grid/tests/grid_subgrid_test.cpp
+++ b/grid/tests/grid_subgrid_test.cpp
@@ -136,7 +136,6 @@ TEST(GridExtractConstRowTest, ValuesNonModifiable)
 
     auto row0 = grid.row(0);
 
-    std::is_const<const int &>::value;
     ASSERT_TRUE(std::is_const<std::remove_reference<decltype(row0[0].get())>::type>::value);
     ASSERT_TRUE(std::is_const<std::remove_reference<decltype(row0[1].get())>::type>::value);
     ASSERT_TRUE(std::is_const<std::remove_reference<decltype(row0[2].get())>::type>::value);
@@ -210,4 +209,70 @@ TEST(GridExtractColTest, ValuesModifiable)
     ASSERT_EQ(grid(0, 0), 10);
     ASSERT_EQ(grid(1, 0), 40);
     ASSERT_EQ(grid(2, 0), 70);
+}
+
+TEST(GridExtractConstColTest, HandleEmpty)
+{
+    const Grid<int> grid;
+
+    auto col0 = grid.col(0);
+
+    EXPECT_EQ(col0.size(), 0);
+    EXPECT_TRUE(col0.empty());
+}
+
+TEST(GridExtractConstColTest, HandleNoColumn)
+{
+    for (size_t i = 1; i <= 5; ++i)
+    {
+        const Grid<int> grid(i, 0);
+
+        EXPECT_THROW(grid.col(0), std::out_of_range);
+    }
+}
+
+TEST(GridExtractConstColTest, HandleNoColRow)
+{
+    for (size_t j = 1; j <= 5; ++j)
+    {
+        const Grid<int> grid(0, j);
+
+        auto col0 = grid.col(0);
+
+        EXPECT_EQ(col0.size(), 0);
+        EXPECT_TRUE(col0.empty());
+    }
+}
+
+TEST(GridExtractConstColTest, accessOutsideRangeColumns)
+{
+    const Grid<int> grid(3, 3, 1);
+
+    EXPECT_THROW(grid.col(3), std::out_of_range);
+}
+
+TEST(GridExtractConstColTest, ContainsCorrectValues)
+{
+    std::vector<int> sourceVals({1, 2, 3, 4, 5, 6, 7, 8, 9});
+
+    const Grid<int> grid(3, 3, sourceVals);
+
+    auto col0 = grid.col(0);
+
+    EXPECT_EQ(col0[0], 1);
+    EXPECT_EQ(col0[1], 4);
+    EXPECT_EQ(col0[2], 7);
+}
+
+TEST(GridExtractConstColTest, ValuesNonModifiable)
+{
+    std::vector<int> sourceVals({1, 2, 3, 4, 5, 6, 7, 8, 9});
+
+    const Grid<int> grid(3, 3, sourceVals);
+
+    auto col0 = grid.col(0);
+
+    ASSERT_TRUE(std::is_const<std::remove_reference<decltype(col0[0].get())>::type>::value);
+    ASSERT_TRUE(std::is_const<std::remove_reference<decltype(col0[1].get())>::type>::value);
+    ASSERT_TRUE(std::is_const<std::remove_reference<decltype(col0[2].get())>::type>::value);
 }


### PR DESCRIPTION
# Features added
- added an method to extract a column that cannot be modified

# Test performed
1. Invoke Ctest in the build folder
2. Validate tests success

# Test configuration
## Test hardwarte
- x86 machine
- i5-8250U
- 32 GB of RAM
## Software
- Windows 10.0.19045
- GCC 12.2.0 x86_64-w64 mingw32
- cmake 3.26.3