### PR TITLE
fix - renamed include guards to the correct ones

### DIFF
--- a/NonogramLevel/include/NonogramLevel/NonogramLevel.hpp
+++ b/NonogramLevel/include/NonogramLevel/NonogramLevel.hpp
@@ -1,5 +1,5 @@
-#ifndef IMAGE_H
-#define IMAGE_H
+#ifndef NONOGREAMLEVEL_H
+#define NONOGREAMLEVEL_H
 
 #include <vector>
 
@@ -30,4 +30,4 @@ namespace NS
     };
 }
 
-#endif /* IMAGE_H */
+#endif /* NONOGREAMLEVEL_H */


### PR DESCRIPTION
# Fixes applied
- Corrected include guards names for nonogram level header file

# Test performed
1. Invoke Ctest in the build folder
2. Validate tests success

# Test configuration
## Test hardwarte
- x86 machine
- Ryzen 5950x
- 32 GB of RAM
## Software
- Windows 10.0.19045
- GCC 12.2.0 x68_64-w64 mingw32
- cmake 3.23.2