### PR TITLE
Feat/nonogram level/add rows and columns methods

### DIFF
--- a/NonogramLevel/include/NonogramLevel/NonogramLevel.hpp
+++ b/NonogramLevel/include/NonogramLevel/NonogramLevel.hpp
@@ -24,6 +24,12 @@ namespace NS
         std::vector<Sequence>& cols();
         const std::vector<Sequence>& cols() const;
 
+        // Row adding methods
+        void addRowSequence(const Sequence& rowSequence);
+        void addRowSequence(Sequence&& rosSequence);
+        void addRowSequences(const std::vector<Sequence>& rowSequences);
+        void addRowSequences(std::vector<Sequence>&& rowSequences);
+
     private:
         std::vector<Sequence> rows_;
         std::vector<Sequence> cols_;

--- a/NonogramLevel/include/NonogramLevel/NonogramLevel.hpp
+++ b/NonogramLevel/include/NonogramLevel/NonogramLevel.hpp
@@ -24,11 +24,17 @@ namespace NS
         std::vector<Sequence>& colSequences();
         const std::vector<Sequence>& colSequences() const;
 
-        // Row adding methods
+        // Row sequences adding methods
         void addRowSequence(const Sequence& rowSequence);
         void addRowSequence(Sequence&& rosSequence);
         void addRowSequences(const std::vector<Sequence>& rowSequences);
         void addRowSequences(std::vector<Sequence>&& rowSequences);
+
+        // Column sequences adding methods
+        void addColSequence(const Sequence& rowSequence);
+        void addColSequence(Sequence&& rosSequence);
+        void addColSequences(const std::vector<Sequence>& rowSequences);
+        void addColSequences(std::vector<Sequence>&& rowSequences);
 
     private:
         std::vector<Sequence> rowSequences_;

--- a/NonogramLevel/include/NonogramLevel/NonogramLevel.hpp
+++ b/NonogramLevel/include/NonogramLevel/NonogramLevel.hpp
@@ -12,17 +12,17 @@ namespace NS
 
         NonogramLevel() = default;
 
-        NonogramLevel(const std::vector<Sequence>& rows, const std::vector<Sequence>& cols);
+        NonogramLevel(const std::vector<Sequence>& rowSequences, const std::vector<Sequence>& colSequences);
 
         NonogramLevel(const NonogramLevel &nonogramLevel);
 
         NonogramLevel(NonogramLevel &&nonogramLevel);
 
         // Accesseurs
-        std::vector<Sequence>& rows();
-        const std::vector<Sequence>& rows() const;
-        std::vector<Sequence>& cols();
-        const std::vector<Sequence>& cols() const;
+        std::vector<Sequence>& rowSequences();
+        const std::vector<Sequence>& rowSequences() const;
+        std::vector<Sequence>& colSequences();
+        const std::vector<Sequence>& colSequences() const;
 
         // Row adding methods
         void addRowSequence(const Sequence& rowSequence);
@@ -31,8 +31,8 @@ namespace NS
         void addRowSequences(std::vector<Sequence>&& rowSequences);
 
     private:
-        std::vector<Sequence> rows_;
-        std::vector<Sequence> cols_;
+        std::vector<Sequence> rowSequences_;
+        std::vector<Sequence> colSequences_;
     };
 }
 

--- a/NonogramLevel/src/NonogramLevel.cpp
+++ b/NonogramLevel/src/NonogramLevel.cpp
@@ -2,37 +2,37 @@
 
 #include <utility>
 
-NS::NonogramLevel::NonogramLevel(const std::vector<Sequence>& rows, const std::vector<Sequence>& cols)
-    : rows_(rows), cols_(cols)
+NS::NonogramLevel::NonogramLevel(const std::vector<Sequence>& rowSequences, const std::vector<Sequence>& colSequences)
+    : rowSequences_(rowSequences), colSequences_(colSequences)
 {
 }
 
 NS::NonogramLevel::NonogramLevel(const NS::NonogramLevel &nonogramLevel)
-    : rows_(nonogramLevel.rows_), cols_(nonogramLevel.cols_)
+    : rowSequences_(nonogramLevel.rowSequences_), colSequences_(nonogramLevel.colSequences_)
 {
 }
 
 NS::NonogramLevel::NonogramLevel(NS::NonogramLevel &&nonogramLevel)
-    : rows_(std::move(nonogramLevel.rows_)), cols_(std::move(nonogramLevel.cols_))
+    : rowSequences_(std::move(nonogramLevel.rowSequences_)), colSequences_(std::move(nonogramLevel.colSequences_))
 {
 }
 
-std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::rows()
+std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::rowSequences()
 {
-    return rows_;
+    return rowSequences_;
 }
 
-const std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::rows() const
+const std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::rowSequences() const
 {
-    return rows_;
+    return rowSequences_;
 }
 
-std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::cols()
+std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::colSequences()
 {
-    return cols_;
+    return colSequences_;
 }
 
-const std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::cols() const
+const std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::colSequences() const
 {
-    return cols_;
+    return colSequences_;
 }

--- a/NonogramLevel/src/NonogramLevel.cpp
+++ b/NonogramLevel/src/NonogramLevel.cpp
@@ -1,6 +1,7 @@
 #include "NonogramLevel.hpp"
 
 #include <utility>
+#include <iterator>
 
 NS::NonogramLevel::NonogramLevel(const std::vector<Sequence>& rowSequences, const std::vector<Sequence>& colSequences)
     : rowSequences_(rowSequences), colSequences_(colSequences)
@@ -35,4 +36,25 @@ std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::colSequences()
 const std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::colSequences() const
 {
     return colSequences_;
+}
+
+void NS::NonogramLevel::addRowSequence(const NS::NonogramLevel::Sequence& rowSequence)
+{
+    rowSequences_.push_back(rowSequence);
+}
+
+void NS::NonogramLevel::addRowSequence(Sequence &&rosSequence)
+{
+    rowSequences_.push_back(std::move(rosSequence));
+}
+
+void NS::NonogramLevel::addRowSequences(const std::vector<NS::NonogramLevel::Sequence>& rowSequences)
+{
+    rowSequences_.insert(rowSequences_.end(), rowSequences.begin(), rowSequences.end());
+}
+
+void NS::NonogramLevel::addRowSequences(std::vector<NS::NonogramLevel::Sequence>&& rowSequences)
+{
+    rowSequences_.insert(rowSequences_.end(),
+        std::make_move_iterator(rowSequences.begin()), std::make_move_iterator(rowSequences.end()));
 }

--- a/NonogramLevel/src/NonogramLevel.cpp
+++ b/NonogramLevel/src/NonogramLevel.cpp
@@ -43,7 +43,7 @@ void NS::NonogramLevel::addRowSequence(const NS::NonogramLevel::Sequence& rowSeq
     rowSequences_.push_back(rowSequence);
 }
 
-void NS::NonogramLevel::addRowSequence(Sequence &&rosSequence)
+void NS::NonogramLevel::addRowSequence(Sequence&& rosSequence)
 {
     rowSequences_.push_back(std::move(rosSequence));
 }
@@ -57,4 +57,25 @@ void NS::NonogramLevel::addRowSequences(std::vector<NS::NonogramLevel::Sequence>
 {
     rowSequences_.insert(rowSequences_.end(),
         std::make_move_iterator(rowSequences.begin()), std::make_move_iterator(rowSequences.end()));
+}
+
+void NS::NonogramLevel::addColSequence(const NS::NonogramLevel::Sequence& colSequence)
+{
+    colSequences_.push_back(colSequence);
+}
+
+void NS::NonogramLevel::addColSequence(Sequence&& rosSequence)
+{
+    rowSequences_.push_back(std::move(rosSequence));
+}
+
+void NS::NonogramLevel::addColSequences(const std::vector<NS::NonogramLevel::Sequence>& colSequences)
+{
+    colSequences_.insert(colSequences_.end(), colSequences.begin(), colSequences.end());
+}
+
+void NS::NonogramLevel::addColSequences(std::vector<NS::NonogramLevel::Sequence>&& colSequences)
+{
+    colSequences_.insert(colSequences_.end(),
+        std::make_move_iterator(colSequences.begin()), std::make_move_iterator(colSequences.end()));
 }

--- a/NonogramLevel/tests/NonogramLevel_test.cpp
+++ b/NonogramLevel/tests/NonogramLevel_test.cpp
@@ -8,26 +8,26 @@ TEST(NonogramLevelDefaultConstructor, isEmpty)
 {
     NS::NonogramLevel nonogramLevel;
 
-    EXPECT_TRUE(nonogramLevel.rows().empty());
-    EXPECT_TRUE(nonogramLevel.cols().empty());
+    EXPECT_TRUE(nonogramLevel.rowSequences().empty());
+    EXPECT_TRUE(nonogramLevel.colSequences().empty());
 }
 
 TEST(NonogramLevelFullConstructor, HandleEmpty)
 {
-    std::vector<NS::NonogramLevel::Sequence> rows;
-    std::vector<NS::NonogramLevel::Sequence> cols;
+    std::vector<NS::NonogramLevel::Sequence> rowSequences;
+    std::vector<NS::NonogramLevel::Sequence> colSequences;
 
-    NS::NonogramLevel nonogramLevel(rows, cols);
+    NS::NonogramLevel nonogramLevel(rowSequences, colSequences);
 
-    EXPECT_TRUE(nonogramLevel.rows().empty());
-    EXPECT_TRUE(nonogramLevel.cols().empty());
+    EXPECT_TRUE(nonogramLevel.rowSequences().empty());
+    EXPECT_TRUE(nonogramLevel.colSequences().empty());
 }
 
 TEST(NonogramLevelFullConstructor, HandleNoRow)
 {
-    std::vector<NS::NonogramLevel::Sequence> rows;
+    std::vector<NS::NonogramLevel::Sequence> rowSequences;
 
-    std::vector<NS::NonogramLevel::Sequence> cols({
+    std::vector<NS::NonogramLevel::Sequence> colSequences({
         NS::NonogramLevel::Sequence({2}),
         NS::NonogramLevel::Sequence({4}),
         NS::NonogramLevel::Sequence({4}),
@@ -35,15 +35,15 @@ TEST(NonogramLevelFullConstructor, HandleNoRow)
         NS::NonogramLevel::Sequence({2}),
     });
 
-    NS::NonogramLevel nonogramLevel(rows, cols);
+    NS::NonogramLevel nonogramLevel(rowSequences, colSequences);
 
-    EXPECT_TRUE(nonogramLevel.rows().empty());
-    EXPECT_EQ(nonogramLevel.cols().size(), 5);
+    EXPECT_TRUE(nonogramLevel.rowSequences().empty());
+    EXPECT_EQ(nonogramLevel.colSequences().size(), 5);
 }
 
 TEST(NonogramLevelFullConstructor, HandleNoColumn)
 {
-    std::vector<NS::NonogramLevel::Sequence> rows({
+    std::vector<NS::NonogramLevel::Sequence> rowSequences({
         NS::NonogramLevel::Sequence({1, 1}),
         NS::NonogramLevel::Sequence({5}),
         NS::NonogramLevel::Sequence({5}),
@@ -51,17 +51,17 @@ TEST(NonogramLevelFullConstructor, HandleNoColumn)
         NS::NonogramLevel::Sequence({1}),
     });
     
-    std::vector<NS::NonogramLevel::Sequence> cols;
+    std::vector<NS::NonogramLevel::Sequence> colSequences;
 
-    NS::NonogramLevel nonogramLevel(rows, cols);
+    NS::NonogramLevel nonogramLevel(rowSequences, colSequences);
 
-    EXPECT_EQ(nonogramLevel.rows().size(), 5);
-    EXPECT_TRUE(nonogramLevel.cols().empty());
+    EXPECT_EQ(nonogramLevel.rowSequences().size(), 5);
+    EXPECT_TRUE(nonogramLevel.colSequences().empty());
 }
 
 TEST(NonogramLevelFullConstructor, CorrectValues)
 {
-    std::vector<NS::NonogramLevel::Sequence> rows({
+    std::vector<NS::NonogramLevel::Sequence> rowSequences({
         NS::NonogramLevel::Sequence({1, 1}),
         NS::NonogramLevel::Sequence({5}),
         NS::NonogramLevel::Sequence({5}),
@@ -69,7 +69,7 @@ TEST(NonogramLevelFullConstructor, CorrectValues)
         NS::NonogramLevel::Sequence({1}),
     });
     
-    std::vector<NS::NonogramLevel::Sequence> cols({
+    std::vector<NS::NonogramLevel::Sequence> colSequences({
         NS::NonogramLevel::Sequence({2}),
         NS::NonogramLevel::Sequence({4}),
         NS::NonogramLevel::Sequence({4}),
@@ -77,8 +77,8 @@ TEST(NonogramLevelFullConstructor, CorrectValues)
         NS::NonogramLevel::Sequence({2}),
     });
 
-    NS::NonogramLevel nonogramLevel(rows, cols);
+    NS::NonogramLevel nonogramLevel(rowSequences, colSequences);
 
-    EXPECT_EQ(nonogramLevel.rows(), rows);
-    EXPECT_EQ(nonogramLevel.cols(), cols);
+    EXPECT_EQ(nonogramLevel.rowSequences(), rowSequences);
+    EXPECT_EQ(nonogramLevel.colSequences(), colSequences);
 }


### PR DESCRIPTION
# Features added
- Added methods to add a row sequence to the nonogram level
- Added methods to add multiple row sequences to the nonogram level
- Added methods to add a column sequence to the nonogram level
- Added methods to add multiple column sequences to the nonogram level

# Test performed
No tests for these features have been added yet, will be done at a later date
1. Invoke Ctest in the build folder
2. Validate tests success

# Test configuration
## Test hardwarte
- x86 machine
- Ryzen 5950x
- 32 GB of RAM
## Software
- Windows 10.0.19045
- GCC 12.2.0 x68_64-w64 mingw32
- cmake 3.23.2