### PR TITLE
Feat/nonogram level/accessors

### DIFF
--- a/NonogramLevel/include/NonogramLevel/NonogramLevel.hpp
+++ b/NonogramLevel/include/NonogramLevel/NonogramLevel.hpp
@@ -8,6 +8,7 @@ namespace NS
     class NonogramLevel
     {
     public:
+        typedef size_t size_type;
         using Sequence = std::vector<unsigned int>;
 
         NonogramLevel() = default;
@@ -19,8 +20,12 @@ namespace NS
         NonogramLevel(NonogramLevel &&nonogramLevel);
 
         // Accesseurs
+        Sequence& rowSequence(size_type row);
+        const Sequence& rowSequence(size_type row) const;
         std::vector<Sequence>& rowSequences();
         const std::vector<Sequence>& rowSequences() const;
+        Sequence& colSequence(size_type col);
+        const Sequence& colSequence(size_type col) const;
         std::vector<Sequence>& colSequences();
         const std::vector<Sequence>& colSequences() const;
 

--- a/NonogramLevel/src/NonogramLevel.cpp
+++ b/NonogramLevel/src/NonogramLevel.cpp
@@ -18,6 +18,16 @@ NS::NonogramLevel::NonogramLevel(NS::NonogramLevel &&nonogramLevel)
 {
 }
 
+NS::NonogramLevel::Sequence& NS::NonogramLevel::rowSequence(size_type row)
+{
+    return rowSequences_.at(row);
+}
+
+const NS::NonogramLevel::Sequence& NS::NonogramLevel::rowSequence(size_type row) const
+{
+    return rowSequences_.at(row);
+}
+
 std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::rowSequences()
 {
     return rowSequences_;
@@ -26,6 +36,16 @@ std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::rowSequences()
 const std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::rowSequences() const
 {
     return rowSequences_;
+}
+
+NS::NonogramLevel::Sequence& NS::NonogramLevel::colSequence(size_type col)
+{
+    return colSequences_.at(col);
+}
+
+const NS::NonogramLevel::Sequence& NS::NonogramLevel::colSequence(size_type col) const
+{
+    return colSequences_.at(col);
 }
 
 std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::colSequences()


### PR DESCRIPTION
# Features added
- Added methods to acess a row sequence of the nonogram level
- Added methods to access a column sequence of the nonogram level

# Test performed
No tests for these features have been added yet, will be done at a later date
1. Invoke Ctest in the build folder
2. Validate tests success

# Test configuration
## Test hardwarte
- x86 machine
- Ryzen 5950x
- 32 GB of RAM
## Software
- Windows 10.0.19045
- GCC 12.2.0 x68_64-w64 mingw32
- cmake 3.23.2