### PR TITLE
Feat/type unification/sequence

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,9 @@ add_subdirectory(Square)
 # Load image library
 add_subdirectory(Image)
 
+# Load sequence library
+add_subdirectory(Sequence)
+
 # Load line sequencer library
 add_subdirectory(LineSequencer)
 

--- a/LineFilter/include/LineFilter/ILineFilter.hpp
+++ b/LineFilter/include/LineFilter/ILineFilter.hpp
@@ -6,7 +6,6 @@
 class ILineFilter
 {
 public:
-    using Sequence = std::vector<unsigned int>;
     using Line = std::vector<unsigned int>;
 
     // Contructors

--- a/LineFilter/include/LineFilter/LineFilterBuilder.hpp
+++ b/LineFilter/include/LineFilter/LineFilterBuilder.hpp
@@ -4,6 +4,8 @@
 #include "ILineFilter.hpp"
 #include "ILineSequencer.hpp"
 
+#include <Sequence.hpp>
+
 class LineFilterBuilder
 {
 public:
@@ -15,7 +17,7 @@ public:
 
     // Building methods
     // Base line filter
-    LineFilterBuilder& sequenceLineFilter(ILineFilter::Sequence sequence,
+    LineFilterBuilder& sequenceLineFilter(NS::Sequence sequence,
                                             ILineSequencer& sequencer);
 
     // Line filter modifiers

--- a/LineFilter/include/LineFilter/SequenceLineFilter.hpp
+++ b/LineFilter/include/LineFilter/SequenceLineFilter.hpp
@@ -2,14 +2,15 @@
 #define SEQUENCERLINEFILTER_H
 
 #include "ILineFilter.hpp"
-
 #include "ILineSequencer.hpp"
+
+#include <Sequence.hpp>
 
 class SequenceLineFilter: public ILineFilter
 {
 public:
     // Contructors
-    SequenceLineFilter(const Sequence& sequence, const ILineSequencer& sequencer);
+    SequenceLineFilter(const NS::Sequence& sequence, const ILineSequencer& sequencer);
 
     // // Destructor
     ~SequenceLineFilter() = default;
@@ -17,7 +18,7 @@ public:
     // Member methods
     virtual bool operator()(Line line) const override;
 protected:
-    const Sequence& sequence_;
+    const NS::Sequence& sequence_;
     const ILineSequencer& sequencer_;
 };
 

--- a/LineFilter/src/CMakeLists.txt
+++ b/LineFilter/src/CMakeLists.txt
@@ -14,7 +14,8 @@ set(HEADER_LIST
     "${line_filter_lib_SOURCE_DIR}/include/LineFilter/LineFilterBuilder.hpp")
 
 set(EXTERNAL_HEADER_LIST
-"${line_sequencer_lib_SOURCE_DIR}/include/LineSequencer/ILineSequencer.hpp")
+    "${line_sequencer_lib_SOURCE_DIR}/include/LineSequencer/ILineSequencer.hpp"
+    "${sequence_lib_SOURCE_DIR}/include/Sequence/Sequence.hpp")
 
 # Make an automatic library - will be static or dynamic based on user setting
 add_library(line_filter_library
@@ -29,10 +30,14 @@ add_library(line_filter_library
             ${HEADER_LIST}
             ${EXTERNAL_HEADER_LIST})
 
+target_link_libraries(line_filter_library PUBLIC
+                        sequence_library)
+
 # We need this directory, and users of our library will need it too
 target_include_directories(line_filter_library PUBLIC
                             ../include/LineFilter
-                            "${line_sequencer_lib_SOURCE_DIR}/include/LineSequencer")
+                            "${line_sequencer_lib_SOURCE_DIR}/include/LineSequencer"
+                            "${sequence_lib_SOURCE_DIR}/include/Sequence")
 
 # All users of this library will need at least C++17
 target_compile_features(line_filter_library PUBLIC cxx_std_17)

--- a/LineFilter/src/LineFilterBuilder.cpp
+++ b/LineFilter/src/LineFilterBuilder.cpp
@@ -5,7 +5,7 @@
 
 #include <stdexcept>
 
-LineFilterBuilder& LineFilterBuilder::sequenceLineFilter(ILineFilter::Sequence sequence, ILineSequencer& sequencer)
+LineFilterBuilder& LineFilterBuilder::sequenceLineFilter(NS::Sequence sequence, ILineSequencer& sequencer)
 {
     if(lineFilter_)
         throw(std::logic_error("Base line filter has already been created, cannot create SequenceLineFilter"));

--- a/LineFilter/src/SequenceLineFilter.cpp
+++ b/LineFilter/src/SequenceLineFilter.cpp
@@ -1,6 +1,6 @@
 #include "SequenceLineFilter.hpp"
 
-SequenceLineFilter::SequenceLineFilter(const Sequence& sequence, const ILineSequencer& sequencer)
+SequenceLineFilter::SequenceLineFilter(const NS::Sequence& sequence, const ILineSequencer& sequencer)
     : sequence_{sequence}, sequencer_{sequencer}
 {
 

--- a/LineFilter/tests/LineFilter_test.cpp
+++ b/LineFilter/tests/LineFilter_test.cpp
@@ -27,35 +27,35 @@ protected:
         // Rows
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 0, 1, 0},
                     {1, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 1},
                     {5}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 1},
                     {5}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 1, 1, 0},
                     {3}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 0, 1, 0, 0},
                     {1}
                 )
@@ -63,35 +63,35 @@ protected:
         // Columns
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 1, 0, 0},
                     {2}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 0},
                     {4}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 1, 1, 1},
                     {4}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 0},
                     {4}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 1, 0, 0},
                     {2}
                 )
@@ -101,70 +101,70 @@ protected:
         // Rows
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 0, 0, 1, 0, 0, 1, 1, 1},
                     {2, 1, 3}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 0, 0, 0, 0, 1, 0, 1, 1},
                     {1, 1, 2}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 0, 0, 0, 0, 1, 0, 1, 1},
                     {1, 1, 2}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 0, 0, 0, 0, 0, 0, 1, 1},
                     {1, 2}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 0, 0, 0, 0, 0, 1, 1, 1},
                     {2, 3}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 0, 0, 0, 1, 1, 1, 1},
                     {3, 4}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 0, 1, 1, 1, 0, 1},
                     {4, 3, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 1, 1, 1, 1, 1, 0, 1, 0},
                     {1, 5, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 0, 1, 1, 0, 1, 1, 0, 1},
                     {1, 2, 2, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 1, 1, 0, 1, 0, 1, 1, 1},
                     {1, 2, 1, 3}
                 )
@@ -172,77 +172,77 @@ protected:
         // Columns
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 1, 1, 1, 1, 0, 1},
                     {8, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 0, 0, 1, 1, 1, 0, 1, 0},
                     {1, 3, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 0, 0, 0, 0, 1, 1, 1, 0, 1},
                     {3, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 0, 0, 0, 0, 0, 1, 1, 1, 1},
                     {4}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 0, 0, 0, 0, 0, 1, 1, 0},
                     {1, 2}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 0, 0, 0, 0, 0, 1, 1, 0, 1},
                     {2, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 1, 0, 0, 1, 1, 1, 1, 0},
                     {2, 4}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 0, 0, 1, 1, 1, 0, 1, 1},
                     {1, 3, 2}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 1, 1, 0, 1, 0, 1},
                     {6, 1, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1},
                     {7, 2}
                 )
             );
     }
 
-    std::vector<std::pair<ILineSequencer::Line, ILineSequencer::Sequence>> testLinesSequences;
+    std::vector<std::pair<ILineSequencer::Line, NS::Sequence>> testLinesSequences;
 };
 
 TEST_F(SequenceLineFilterTest, SequenceLineFilter) {

--- a/LineGenerator/include/LineGenerator/ILineGenerator.hpp
+++ b/LineGenerator/include/LineGenerator/ILineGenerator.hpp
@@ -2,14 +2,14 @@
 #define ILINEGENERATOR_H
 
 #include <vector>
-#include <string>
+
+#include <Sequence.hpp>
 
 namespace NS
 {
     class ILineGenerator
     {
     public:
-        using Sequence = std::vector<unsigned int>;
         using Line = std::vector<unsigned int>;
 
         // Constructors

--- a/LineGenerator/src/CMakeLists.txt
+++ b/LineGenerator/src/CMakeLists.txt
@@ -11,8 +11,7 @@ set(HEADER_LIST
     "${line_generator_lib_SOURCE_DIR}/include/LineGenerator/LineGeneratorBuilder.hpp")
 
 set(EXTERNAL_HEADER_LIST
-    "${line_filter_lib_SOURCE_DIR}/include/LineFilter/ILineFilter.hpp"
-    "${sequence_lib_SOURCE_DIR}/include/Sequence/Sequence.hpp")
+    "${line_filter_lib_SOURCE_DIR}/include/LineFilter/ILineFilter.hpp")
 
 # Make an automatic library - will be static or dynamic based on user setting
 add_library(line_generator_library
@@ -25,14 +24,12 @@ add_library(line_generator_library
             ${EXTERNAL_HEADER_LIST})
 
 target_link_libraries(line_generator_library
-                        line_filter_library
-                        sequence_library)
+                        line_filter_library)
 
 # We need this directory, and users of our library will need it too
 target_include_directories(line_generator_library PUBLIC
                             ../include/LineGenerator
-                            "${line_filter_lib_SOURCE_DIR}/include"
-                            "${sequence_lib_SOURCE_DIR}/include/Sequence")
+                            "${line_filter_lib_SOURCE_DIR}/include")
 
 # All users of this library will need at least C++17
 target_compile_features(line_generator_library PUBLIC cxx_std_17)

--- a/LineGenerator/src/CMakeLists.txt
+++ b/LineGenerator/src/CMakeLists.txt
@@ -11,7 +11,8 @@ set(HEADER_LIST
     "${line_generator_lib_SOURCE_DIR}/include/LineGenerator/LineGeneratorBuilder.hpp")
 
 set(EXTERNAL_HEADER_LIST
-    "${line_filter_lib_SOURCE_DIR}/include/LineFilter/ILineFilter.hpp")
+    "${line_filter_lib_SOURCE_DIR}/include/LineFilter/ILineFilter.hpp"
+    "${sequence_lib_SOURCE_DIR}/include/Sequence/Sequence.hpp")
 
 # Make an automatic library - will be static or dynamic based on user setting
 add_library(line_generator_library
@@ -24,12 +25,14 @@ add_library(line_generator_library
             ${EXTERNAL_HEADER_LIST})
 
 target_link_libraries(line_generator_library
-                        line_filter_library)
+                        line_filter_library
+                        sequence_library)
 
 # We need this directory, and users of our library will need it too
 target_include_directories(line_generator_library PUBLIC
                             ../include/LineGenerator
-                            "${line_filter_lib_SOURCE_DIR}/include")
+                            "${line_filter_lib_SOURCE_DIR}/include"
+                            "${sequence_lib_SOURCE_DIR}/include/Sequence")
 
 # All users of this library will need at least C++17
 target_compile_features(line_generator_library PUBLIC cxx_std_17)

--- a/LineGenerator/tests/LineGenerator_test.cpp
+++ b/LineGenerator/tests/LineGenerator_test.cpp
@@ -172,7 +172,7 @@ class LineGeneratorFilterTest: public ::testing::Test
 {
 protected:
     // test case type
-    using testCaseType = std::tuple<unsigned int, ILineSequencer::Sequence,
+    using testCaseType = std::tuple<unsigned int, NS::Sequence,
                             std::vector<NS::ILineGenerator::Line>>;
 
     void SetUp() override

--- a/LineSequencer/include/LineSequencer/FSTLineSequencer.hpp
+++ b/LineSequencer/include/LineSequencer/FSTLineSequencer.hpp
@@ -14,7 +14,7 @@ public:
     ~FSTLineSequencer() = default;
 
     // Member methods
-    virtual Sequence operator()(Line line) const;
+    virtual NS::Sequence operator()(Line line) const;
 };
 
 #endif /* FSTLINESEQUENCER_H */

--- a/LineSequencer/include/LineSequencer/ILineSequencer.hpp
+++ b/LineSequencer/include/LineSequencer/ILineSequencer.hpp
@@ -3,10 +3,11 @@
 
 #include <vector>
 
+#include <Sequence.hpp>
+
 class ILineSequencer
 {
 public:
-    using Sequence = std::vector<unsigned int>;
     using Line = std::vector<unsigned int>;
 
     // Constructor
@@ -16,7 +17,7 @@ public:
     ~ILineSequencer() = default;
 
     // Member methods
-    virtual Sequence operator()(Line line) const = 0;
+    virtual NS::Sequence operator()(Line line) const = 0;
 };
 
 #endif /* ILINESEQUENCER_H */

--- a/LineSequencer/src/CMakeLists.txt
+++ b/LineSequencer/src/CMakeLists.txt
@@ -7,15 +7,23 @@ set(HEADER_LIST
     "${line_sequencer_lib_SOURCE_DIR}/include/LineSequencer/ILineSequencer.hpp"
     "${line_sequencer_lib_SOURCE_DIR}/include/LineSequencer/FSTLineSequencer.hpp")
 
+set(EXTERNAL_HEADER_LIST
+    "${sequence_lib_SOURCE_DIR}/include/Sequence/Sequence.hpp")
+
 # Make an automatic library - will be static or dynamic based on user setting
 add_library(line_sequencer_library
             ILineSequencer.cpp
             FSTLineSequencer.cpp
-            ${HEADER_LIST})
+            ${HEADER_LIST}
+            ${EXTERNAL_HEADER_LIST})
+
+target_link_libraries(line_sequencer_library PUBLIC
+                        sequence_library)
 
 # We need this directory, and users of our library will need it too
 target_include_directories(line_sequencer_library PUBLIC
-                            ../include/LineSequencer)
+                            ../include/LineSequencer
+                            "${sequence_lib_SOURCE_DIR}/include/Sequence")
 
 # All users of this library will need at least C++17
 target_compile_features(line_sequencer_library PUBLIC cxx_std_17)

--- a/LineSequencer/src/FSTLineSequencer.cpp
+++ b/LineSequencer/src/FSTLineSequencer.cpp
@@ -3,7 +3,7 @@
 #include <stdexcept>
 #include <sstream>
 
-FSTLineSequencer::Sequence FSTLineSequencer::operator()(Line line) const
+NS::Sequence FSTLineSequencer::operator()(Line line) const
 {
     // Current state, represent the last value read from the line
     unsigned int state = 0;
@@ -11,7 +11,7 @@ FSTLineSequencer::Sequence FSTLineSequencer::operator()(Line line) const
     // index of group, used to increment number of tiles in said group
     unsigned int groupIndex = 0;
 
-    Sequence seq;
+    NS::Sequence seq;
     
     for(const auto& tile : line) {
         switch (state)

--- a/LineSequencer/tests/FSTLineSequencer_test.cpp
+++ b/LineSequencer/tests/FSTLineSequencer_test.cpp
@@ -19,35 +19,35 @@ protected:
         // Rows
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 0, 1, 0},
                     {1, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 1},
                     {5}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 1},
                     {5}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 1, 1, 0},
                     {3}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 0, 1, 0, 0},
                     {1}
                 )
@@ -55,35 +55,35 @@ protected:
         // Columns
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 1, 0, 0},
                     {2}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 0},
                     {4}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 1, 1, 1},
                     {4}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 0},
                     {4}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 1, 0, 0},
                     {2}
                 )
@@ -93,70 +93,70 @@ protected:
         // Rows
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 0, 0, 1, 0, 0, 1, 1, 1},
                     {2, 1, 3}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 0, 0, 0, 0, 1, 0, 1, 1},
                     {1, 1, 2}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 0, 0, 0, 0, 1, 0, 1, 1},
                     {1, 1, 2}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 0, 0, 0, 0, 0, 0, 1, 1},
                     {1, 2}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 0, 0, 0, 0, 0, 1, 1, 1},
                     {2, 3}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 0, 0, 0, 1, 1, 1, 1},
                     {3, 4}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 0, 1, 1, 1, 0, 1},
                     {4, 3, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 1, 1, 1, 1, 1, 0, 1, 0},
                     {1, 5, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 0, 1, 1, 0, 1, 1, 0, 1},
                     {1, 2, 2, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 1, 1, 0, 1, 0, 1, 1, 1},
                     {1, 2, 1, 3}
                 )
@@ -164,77 +164,77 @@ protected:
         // Columns
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 1, 1, 1, 1, 0, 1},
                     {8, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 0, 0, 1, 1, 1, 0, 1, 0},
                     {1, 3, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 0, 0, 0, 0, 1, 1, 1, 0, 1},
                     {3, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 0, 0, 0, 0, 0, 1, 1, 1, 1},
                     {4}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 0, 0, 0, 0, 0, 1, 1, 0},
                     {1, 2}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 0, 0, 0, 0, 0, 1, 1, 0, 1},
                     {2, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {0, 1, 1, 0, 0, 1, 1, 1, 1, 0},
                     {2, 4}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 0, 0, 0, 1, 1, 1, 0, 1, 1},
                     {1, 3, 2}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 1, 1, 0, 1, 0, 1},
                     {6, 1, 1}
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, ILineSequencer::Sequence>(
+                std::pair<ILineSequencer::Line, NS::Sequence>(
                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1},
                     {7, 2}
                 )
             );
     }
 
-    std::vector<std::pair<ILineSequencer::Line, ILineSequencer::Sequence>> testLinesSequences;
+    std::vector<std::pair<ILineSequencer::Line, NS::Sequence>> testLinesSequences;
 };
 
 TEST_F(LineSequencerTest, FSTLineSequencer) {

--- a/NonogramLevel/include/NonogramLevel/NonogramLevel.hpp
+++ b/NonogramLevel/include/NonogramLevel/NonogramLevel.hpp
@@ -4,13 +4,14 @@
 #include <cstddef>
 #include <vector>
 
+#include <Sequence.hpp>
+
 namespace NS
 {
     class NonogramLevel
     {
     public:
         typedef size_t size_type;
-        using Sequence = std::vector<unsigned int>;
 
         NonogramLevel() = default;
 

--- a/NonogramLevel/src/CMakeLists.txt
+++ b/NonogramLevel/src/CMakeLists.txt
@@ -6,14 +6,22 @@
 set(HEADER_LIST
     "${nonogram_level_lib_SOURCE_DIR}/include/NonogramLevel/NonogramLevel.hpp")
 
+set(EXTERNAL_HEADER_LIST
+    "${sequence_lib_SOURCE_DIR}/include/Sequence/Sequence.hpp")
+
 # Make an automatic library - will be static or dynamic based on user setting
 add_library(nonogram_level_library
             NonogramLevel.cpp
-            ${HEADER_LIST})
+            ${HEADER_LIST}
+            ${EXTERNAL_HEADER_LIST})
+
+target_link_libraries(nonogram_level_library PUBLIC
+						sequence_library)
 
 # We need this directory, and users of our library will need it too
 target_include_directories(nonogram_level_library PUBLIC
-                            ../include/NonogramLevel)
+                            ../include/NonogramLevel
+                            "${sequence_lib_SOURCE_DIR}/include/Sequence")
 
 # All users of this library will need at least C++17
 target_compile_features(nonogram_level_library PUBLIC cxx_std_17)

--- a/NonogramLevel/src/NonogramLevel.cpp
+++ b/NonogramLevel/src/NonogramLevel.cpp
@@ -18,47 +18,47 @@ NS::NonogramLevel::NonogramLevel(NS::NonogramLevel &&nonogramLevel)
 {
 }
 
-NS::NonogramLevel::Sequence& NS::NonogramLevel::rowSequence(size_type row)
+NS::Sequence& NS::NonogramLevel::rowSequence(size_type row)
 {
     return rowSequences_.at(row);
 }
 
-const NS::NonogramLevel::Sequence& NS::NonogramLevel::rowSequence(size_type row) const
+const NS::Sequence& NS::NonogramLevel::rowSequence(size_type row) const
 {
     return rowSequences_.at(row);
 }
 
-std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::rowSequences()
+std::vector<NS::Sequence>& NS::NonogramLevel::rowSequences()
 {
     return rowSequences_;
 }
 
-const std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::rowSequences() const
+const std::vector<NS::Sequence>& NS::NonogramLevel::rowSequences() const
 {
     return rowSequences_;
 }
 
-NS::NonogramLevel::Sequence& NS::NonogramLevel::colSequence(size_type col)
+NS::Sequence& NS::NonogramLevel::colSequence(size_type col)
 {
     return colSequences_.at(col);
 }
 
-const NS::NonogramLevel::Sequence& NS::NonogramLevel::colSequence(size_type col) const
+const NS::Sequence& NS::NonogramLevel::colSequence(size_type col) const
 {
     return colSequences_.at(col);
 }
 
-std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::colSequences()
+std::vector<NS::Sequence>& NS::NonogramLevel::colSequences()
 {
     return colSequences_;
 }
 
-const std::vector<NS::NonogramLevel::Sequence>& NS::NonogramLevel::colSequences() const
+const std::vector<NS::Sequence>& NS::NonogramLevel::colSequences() const
 {
     return colSequences_;
 }
 
-void NS::NonogramLevel::addRowSequence(const NS::NonogramLevel::Sequence& rowSequence)
+void NS::NonogramLevel::addRowSequence(const NS::Sequence& rowSequence)
 {
     rowSequences_.push_back(rowSequence);
 }
@@ -68,18 +68,18 @@ void NS::NonogramLevel::addRowSequence(Sequence&& rosSequence)
     rowSequences_.push_back(std::move(rosSequence));
 }
 
-void NS::NonogramLevel::addRowSequences(const std::vector<NS::NonogramLevel::Sequence>& rowSequences)
+void NS::NonogramLevel::addRowSequences(const std::vector<NS::Sequence>& rowSequences)
 {
     rowSequences_.insert(rowSequences_.end(), rowSequences.begin(), rowSequences.end());
 }
 
-void NS::NonogramLevel::addRowSequences(std::vector<NS::NonogramLevel::Sequence>&& rowSequences)
+void NS::NonogramLevel::addRowSequences(std::vector<NS::Sequence>&& rowSequences)
 {
     rowSequences_.insert(rowSequences_.end(),
         std::make_move_iterator(rowSequences.begin()), std::make_move_iterator(rowSequences.end()));
 }
 
-void NS::NonogramLevel::addColSequence(const NS::NonogramLevel::Sequence& colSequence)
+void NS::NonogramLevel::addColSequence(const NS::Sequence& colSequence)
 {
     colSequences_.push_back(colSequence);
 }
@@ -89,12 +89,12 @@ void NS::NonogramLevel::addColSequence(Sequence&& rosSequence)
     rowSequences_.push_back(std::move(rosSequence));
 }
 
-void NS::NonogramLevel::addColSequences(const std::vector<NS::NonogramLevel::Sequence>& colSequences)
+void NS::NonogramLevel::addColSequences(const std::vector<NS::Sequence>& colSequences)
 {
     colSequences_.insert(colSequences_.end(), colSequences.begin(), colSequences.end());
 }
 
-void NS::NonogramLevel::addColSequences(std::vector<NS::NonogramLevel::Sequence>&& colSequences)
+void NS::NonogramLevel::addColSequences(std::vector<NS::Sequence>&& colSequences)
 {
     colSequences_.insert(colSequences_.end(),
         std::make_move_iterator(colSequences.begin()), std::make_move_iterator(colSequences.end()));

--- a/NonogramLevel/tests/NonogramLevel_test.cpp
+++ b/NonogramLevel/tests/NonogramLevel_test.cpp
@@ -14,8 +14,8 @@ TEST(NonogramLevelDefaultConstructor, isEmpty)
 
 TEST(NonogramLevelFullConstructor, HandleEmpty)
 {
-    std::vector<NS::NonogramLevel::Sequence> rowSequences;
-    std::vector<NS::NonogramLevel::Sequence> colSequences;
+    std::vector<NS::Sequence> rowSequences;
+    std::vector<NS::Sequence> colSequences;
 
     NS::NonogramLevel nonogramLevel(rowSequences, colSequences);
 
@@ -25,14 +25,14 @@ TEST(NonogramLevelFullConstructor, HandleEmpty)
 
 TEST(NonogramLevelFullConstructor, HandleNoRow)
 {
-    std::vector<NS::NonogramLevel::Sequence> rowSequences;
+    std::vector<NS::Sequence> rowSequences;
 
-    std::vector<NS::NonogramLevel::Sequence> colSequences({
-        NS::NonogramLevel::Sequence({2}),
-        NS::NonogramLevel::Sequence({4}),
-        NS::NonogramLevel::Sequence({4}),
-        NS::NonogramLevel::Sequence({4}),
-        NS::NonogramLevel::Sequence({2}),
+    std::vector<NS::Sequence> colSequences({
+        NS::Sequence({2}),
+        NS::Sequence({4}),
+        NS::Sequence({4}),
+        NS::Sequence({4}),
+        NS::Sequence({2}),
     });
 
     NS::NonogramLevel nonogramLevel(rowSequences, colSequences);
@@ -43,15 +43,15 @@ TEST(NonogramLevelFullConstructor, HandleNoRow)
 
 TEST(NonogramLevelFullConstructor, HandleNoColumn)
 {
-    std::vector<NS::NonogramLevel::Sequence> rowSequences({
-        NS::NonogramLevel::Sequence({1, 1}),
-        NS::NonogramLevel::Sequence({5}),
-        NS::NonogramLevel::Sequence({5}),
-        NS::NonogramLevel::Sequence({3}),
-        NS::NonogramLevel::Sequence({1}),
+    std::vector<NS::Sequence> rowSequences({
+        NS::Sequence({1, 1}),
+        NS::Sequence({5}),
+        NS::Sequence({5}),
+        NS::Sequence({3}),
+        NS::Sequence({1}),
     });
     
-    std::vector<NS::NonogramLevel::Sequence> colSequences;
+    std::vector<NS::Sequence> colSequences;
 
     NS::NonogramLevel nonogramLevel(rowSequences, colSequences);
 
@@ -61,20 +61,20 @@ TEST(NonogramLevelFullConstructor, HandleNoColumn)
 
 TEST(NonogramLevelFullConstructor, CorrectValues)
 {
-    std::vector<NS::NonogramLevel::Sequence> rowSequences({
-        NS::NonogramLevel::Sequence({1, 1}),
-        NS::NonogramLevel::Sequence({5}),
-        NS::NonogramLevel::Sequence({5}),
-        NS::NonogramLevel::Sequence({3}),
-        NS::NonogramLevel::Sequence({1}),
+    std::vector<NS::Sequence> rowSequences({
+        NS::Sequence({1, 1}),
+        NS::Sequence({5}),
+        NS::Sequence({5}),
+        NS::Sequence({3}),
+        NS::Sequence({1}),
     });
     
-    std::vector<NS::NonogramLevel::Sequence> colSequences({
-        NS::NonogramLevel::Sequence({2}),
-        NS::NonogramLevel::Sequence({4}),
-        NS::NonogramLevel::Sequence({4}),
-        NS::NonogramLevel::Sequence({4}),
-        NS::NonogramLevel::Sequence({2}),
+    std::vector<NS::Sequence> colSequences({
+        NS::Sequence({2}),
+        NS::Sequence({4}),
+        NS::Sequence({4}),
+        NS::Sequence({4}),
+        NS::Sequence({2}),
     });
 
     NS::NonogramLevel nonogramLevel(rowSequences, colSequences);

--- a/Sequence/CMakeLists.txt
+++ b/Sequence/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Works with 3.14
+cmake_minimum_required(VERSION 3.14)
+
+# Project name and a few useful settings. Other commands can pick up the results
+project(
+    sequence_lib
+    VERSION 0.1
+    DESCRIPTION "Library containing type definition for a sequence as an array of unsigned integers"
+    LANGUAGES CXX)
+
+# Only do these if this is the main project, and not if it is included through
+# add_subdirectory
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    # Let's ensure -std=c++xx instead of -std=g++xx
+    set(CMAKE_CXX_EXTENSIONS OFF)
+
+    # Let's nicely support folders in IDE's
+    set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+    # Testing only available if this is the main app. Note this needs to be done
+    # in the main CMakeLists since it calls enable_testing, which must be in the
+    # main CMakeLists.
+    include(CTest)
+
+    # Docs only available if this is the main app
+    find_package(Doxygen)
+    if(Doxygen_FOUND)
+        add_subdirectory(docs)
+    else()
+        message(STATUS "Doxygen not found, not building docs")
+    endif()
+endif()
+
+# Load external dependencies
+add_subdirectory(extern)
+
+# The compiled library code is here
+add_subdirectory(src)
+
+# The executable code is here
+add_subdirectory(apps)
+
+# Testing only available if this is the main app
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/Sequence/include/Sequence/Sequence.hpp
+++ b/Sequence/include/Sequence/Sequence.hpp
@@ -1,9 +1,11 @@
 #ifndef SEQUENCE_H
 #define SEQUENCE_H
 
+#include <vector>
+
 namespace NS
 {
-    
+    using Sequence = std::vector<unsigned int>;
 }
 
 #endif /* SEQUENCE_H */

--- a/Sequence/include/Sequence/Sequence.hpp
+++ b/Sequence/include/Sequence/Sequence.hpp
@@ -1,0 +1,9 @@
+#ifndef SEQUENCE_H
+#define SEQUENCE_H
+
+namespace NS
+{
+    
+}
+
+#endif /* SEQUENCE_H */

--- a/Sequence/src/CMakeLists.txt
+++ b/Sequence/src/CMakeLists.txt
@@ -7,12 +7,11 @@ set(HEADER_LIST
     "${sequence_lib_SOURCE_DIR}/include/Sequence/Sequence.hpp")
 
 # Make an automatic library - will be static or dynamic based on user setting
-add_library(sequence_library
-            Sequence.cpp
+add_library(sequence_library INTERFACE
             ${HEADER_LIST})
 
 # We need this directory, and users of our library will need it too
-target_include_directories(sequence_library PUBLIC
+target_include_directories(sequence_library INTERFACE
                             "${sequence_lib_SOURCE_DIR}/include/Sequence")
 
 # All users of this library will need at least C++17

--- a/Sequence/src/CMakeLists.txt
+++ b/Sequence/src/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Note that headers are optional, and do not affect add_library, but they will
+# not show up in IDEs unless they are listed in add_library.
+
+# Optionally glob, but only for CMake 3.12 or later: file(GLOB HEADER_LIST
+# CONFIGURE_DEPENDS "${minecraft_block_finder_SOURCE_DIR}/include/modern/*.hpp")
+set(HEADER_LIST
+    "${sequence_lib_SOURCE_DIR}/include/Sequence/Sequence.hpp")
+
+# Make an automatic library - will be static or dynamic based on user setting
+add_library(sequence_library
+            Sequence.cpp
+            ${HEADER_LIST})
+
+# We need this directory, and users of our library will need it too
+target_include_directories(sequence_library PUBLIC
+                            "${sequence_lib_SOURCE_DIR}/include/Sequence")
+
+# All users of this library will need at least C++17
+target_compile_features(sequence_library INTERFACE cxx_std_17)
+
+# IDEs should put the headers in a nice place
+source_group(
+  TREE "${PROJECT_SOURCE_DIR}/include"
+  PREFIX "Header Files"
+  FILES ${HEADER_LIST})

--- a/Sequence/src/Sequence.cpp
+++ b/Sequence/src/Sequence.cpp
@@ -1,0 +1,1 @@
+#include "Sequence.hpp"

--- a/Sequence/tests/CMakeLists.txt
+++ b/Sequence/tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Testing library
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG release-1.12.1
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+add_executable(
+    sequence_test
+    Sequence_test.cpp
+)
+
+target_link_libraries(
+    sequence_test
+    sequence_library
+    GTest::gtest_main
+)
+
+include(GoogleTest)
+gtest_discover_tests(sequence_test)

--- a/Sequence/tests/Sequence_test.cpp
+++ b/Sequence/tests/Sequence_test.cpp
@@ -1,0 +1,3 @@
+#include <gtest/gtest.h>
+
+#include <Sequence.hpp>

--- a/Solver/include/Solver/ISolver.hpp
+++ b/Solver/include/Solver/ISolver.hpp
@@ -4,12 +4,13 @@
 #include <vector>
 #include <grid.hpp>
 
+#include <Sequence.hpp>
+
 namespace NS
 {
     class ISolver
     {
     public:
-        using Sequence = std::vector<unsigned int>;
         using Image = Grid<int>;
 
         struct Nonogram

--- a/Solver/src/CMakeLists.txt
+++ b/Solver/src/CMakeLists.txt
@@ -7,7 +7,8 @@ set(HEADER_LIST
     "${solver_lib_SOURCE_DIR}/include/Solver/ISolver.hpp")
 
 set(EXTERNAL_HEADER_LIST
-    "${grid_lib_SOURCE_DIR}/include/grid/grid.hpp")
+    "${grid_lib_SOURCE_DIR}/include/grid/grid.hpp"
+    "${sequence_lib_SOURCE_DIR}/include/Sequence/Sequence.hpp")
 
 # Make an automatic library - will be static or dynamic based on user setting
 add_library(solver_library
@@ -16,11 +17,13 @@ add_library(solver_library
             ${EXTERNAL_HEADER_LIST})
 
 target_link_libraries(solver_library
-                        grid_library)
+                        grid_library
+						sequence_library)
 
 # We need this directory, and users of our library will need it too
 target_include_directories(solver_library PUBLIC
-                            ../include/Solver)
+                            ../include/Solver
+                            "${sequence_lib_SOURCE_DIR}/include/Sequence")
 
 # All users of this library will need at least C++17
 target_compile_features(solver_library PUBLIC cxx_std_17)


### PR DESCRIPTION
# Features added
- Added definition of Sequence as an array of unsigned integer
- Replaced all references to library specific definitions of Sequence with the newly created one
- Removed all library specific definitions of Sequence

# Test performed
1. Invoke Ctest in the build folder
2. Validate tests success

SequenceLineFilterTest.LineFilterBuilder is gonna be solved in a later patch

# Test configuration
## Test hardwarte
- x86-64 machine
- Ryzen 9 5950x
- 32 GB of RAM

## Software
- Linux Mint 21.3
- Kernel 5.15.0-101-generic
- GCC 12.3.0
- CMake 3.22.1