### PR TITLE
Feat/line filter/smart pointers for dependency injection

### DIFF
--- a/LineFilter/include/LineFilter/ILineFilter.hpp
+++ b/LineFilter/include/LineFilter/ILineFilter.hpp
@@ -15,7 +15,7 @@ public:
     virtual ~ILineFilter() = default;
 
     // Member methods
-    virtual bool operator()(Line line) const = 0;
+    virtual bool operator()(Line& line) const = 0;
 };
 
 #endif /* ILINEFILTER_H */

--- a/LineFilter/include/LineFilter/ILineFilter.hpp
+++ b/LineFilter/include/LineFilter/ILineFilter.hpp
@@ -15,7 +15,7 @@ public:
     virtual ~ILineFilter() = default;
 
     // Member methods
-    virtual bool operator()(Line& line) const = 0;
+    virtual bool operator()(const Line& line) const = 0;
 };
 
 #endif /* ILINEFILTER_H */

--- a/LineFilter/include/LineFilter/ILineFilterModifier.hpp
+++ b/LineFilter/include/LineFilter/ILineFilterModifier.hpp
@@ -3,6 +3,8 @@
 
 #include "ILineFilter.hpp"
 
+#include <memory>
+
 class ILineFilterModifier: public ILineFilter
 {
 public:
@@ -13,7 +15,7 @@ public:
     virtual ~ILineFilterModifier();
 
 protected:
-    ILineFilter* lineFilter_;
+    std::unique_ptr<ILineFilter> lineFilter_;
 };
 
 #endif /* ILINEFILTERMODIFIER_H */

--- a/LineFilter/include/LineFilter/ILineFilterModifier.hpp
+++ b/LineFilter/include/LineFilter/ILineFilterModifier.hpp
@@ -9,7 +9,7 @@ class ILineFilterModifier: public ILineFilter
 {
 public:
     // Constructors
-    ILineFilterModifier(ILineFilter* lineFilter);
+    ILineFilterModifier(std::unique_ptr<ILineFilter> lineFilter);
 
     // Destructor
     virtual ~ILineFilterModifier();

--- a/LineFilter/include/LineFilter/LineEmptyFilter.hpp
+++ b/LineFilter/include/LineFilter/LineEmptyFilter.hpp
@@ -11,7 +11,7 @@ public:
     using ReferenceLine = std::vector<int>;
 
     // Constructors
-    LineEmptyFilter(std::unique_ptr<const ReferenceLine> lineToMatch);
+    LineEmptyFilter(std::shared_ptr<const ReferenceLine> lineToMatch);
 
     // Destructor
     ~LineEmptyFilter() = default;
@@ -20,7 +20,7 @@ public:
     virtual bool operator()(const Line& line) const override;
 
 protected:
-    const std::unique_ptr<const ReferenceLine> lineToMatch_;
+    const std::shared_ptr<const ReferenceLine> lineToMatch_;
 };
 
 #endif /* ILINEEMPTYFILTER_H */

--- a/LineFilter/include/LineFilter/LineEmptyFilter.hpp
+++ b/LineFilter/include/LineFilter/LineEmptyFilter.hpp
@@ -17,7 +17,7 @@ public:
     ~LineEmptyFilter() = default;
 
     // Member methods
-    virtual bool operator()(Line line) const override;
+    virtual bool operator()(Line& line) const override;
 
 protected:
     const std::unique_ptr<const ReferenceLine> lineToMatch_;

--- a/LineFilter/include/LineFilter/LineEmptyFilter.hpp
+++ b/LineFilter/include/LineFilter/LineEmptyFilter.hpp
@@ -3,13 +3,15 @@
 
 #include "ILineFilter.hpp"
 
+#include <memory>
+
 class LineEmptyFilter: public ILineFilter
 {
 public:
     using ReferenceLine = std::vector<int>;
 
     // Constructors
-    LineEmptyFilter(const ReferenceLine& lineToMatch);
+    LineEmptyFilter(std::unique_ptr<const ReferenceLine> lineToMatch);
 
     // Destructor
     ~LineEmptyFilter() = default;
@@ -18,7 +20,7 @@ public:
     virtual bool operator()(Line line) const override;
 
 protected:
-    const ReferenceLine& lineToMatch_;
+    const std::unique_ptr<const ReferenceLine> lineToMatch_;
 };
 
 #endif /* ILINEEMPTYFILTER_H */

--- a/LineFilter/include/LineFilter/LineEmptyFilter.hpp
+++ b/LineFilter/include/LineFilter/LineEmptyFilter.hpp
@@ -17,7 +17,7 @@ public:
     ~LineEmptyFilter() = default;
 
     // Member methods
-    virtual bool operator()(Line& line) const override;
+    virtual bool operator()(const Line& line) const override;
 
 protected:
     const std::unique_ptr<const ReferenceLine> lineToMatch_;

--- a/LineFilter/include/LineFilter/LineFillFilter.hpp
+++ b/LineFilter/include/LineFilter/LineFillFilter.hpp
@@ -11,7 +11,7 @@ public:
     using ReferenceLine = std::vector<int>;
 
     // Constructors
-    LineFillFilter(std::unique_ptr<const ReferenceLine> lineToMatch);
+    LineFillFilter(std::shared_ptr<const ReferenceLine> lineToMatch);
 
     // Destructor
     ~LineFillFilter() = default;
@@ -20,7 +20,7 @@ public:
     virtual bool operator()(const Line& line) const override;
 
 protected:
-    std::unique_ptr<const ReferenceLine> lineToMatch_;
+    std::shared_ptr<const ReferenceLine> lineToMatch_;
 };
 
 #endif /* ILINEFILLFILTER_H */

--- a/LineFilter/include/LineFilter/LineFillFilter.hpp
+++ b/LineFilter/include/LineFilter/LineFillFilter.hpp
@@ -17,7 +17,7 @@ public:
     ~LineFillFilter() = default;
 
     // Member methods
-    virtual bool operator()(Line line) const override;
+    virtual bool operator()(Line& line) const override;
 
 protected:
     std::unique_ptr<const ReferenceLine> lineToMatch_;

--- a/LineFilter/include/LineFilter/LineFillFilter.hpp
+++ b/LineFilter/include/LineFilter/LineFillFilter.hpp
@@ -3,13 +3,15 @@
 
 #include "ILineFilter.hpp"
 
+#include <memory>
+
 class LineFillFilter: public ILineFilter
 {
 public:
     using ReferenceLine = std::vector<int>;
 
     // Constructors
-    LineFillFilter(const ReferenceLine& lineToMatch);
+    LineFillFilter(std::unique_ptr<const ReferenceLine> lineToMatch);
 
     // Destructor
     ~LineFillFilter() = default;
@@ -18,7 +20,7 @@ public:
     virtual bool operator()(Line line) const override;
 
 protected:
-    const ReferenceLine& lineToMatch_;
+    std::unique_ptr<const ReferenceLine> lineToMatch_;
 };
 
 #endif /* ILINEFILLFILTER_H */

--- a/LineFilter/include/LineFilter/LineFillFilter.hpp
+++ b/LineFilter/include/LineFilter/LineFillFilter.hpp
@@ -17,7 +17,7 @@ public:
     ~LineFillFilter() = default;
 
     // Member methods
-    virtual bool operator()(Line& line) const override;
+    virtual bool operator()(const Line& line) const override;
 
 protected:
     std::unique_ptr<const ReferenceLine> lineToMatch_;

--- a/LineFilter/include/LineFilter/LineFilterBuilder.hpp
+++ b/LineFilter/include/LineFilter/LineFilterBuilder.hpp
@@ -4,6 +4,7 @@
 #include "ILineFilter.hpp"
 #include "ILineSequencer.hpp"
 
+#include <memory>
 #include <Sequence.hpp>
 
 class LineFilterBuilder
@@ -17,20 +18,20 @@ public:
 
     // Building methods
     // Base line filter
-    LineFilterBuilder& sequenceLineFilter(NS::Sequence sequence,
-                                            ILineSequencer& sequencer);
+    LineFilterBuilder& sequenceLineFilter(std::shared_ptr<const NS::Sequence> sequence,
+                                            std::shared_ptr<const ILineSequencer> sequencer);
 
     // Line filter modifiers
     LineFilterBuilder& lineFilterInverter();
 
     // Make line filter
-    ILineFilter* makeLineFilter();
+    std::unique_ptr<ILineFilter> makeLineFilter();
 
     // Reset builder
     LineFilterBuilder& reset();
 
 private:
-    ILineFilter* lineFilter_ = nullptr;
+    std::unique_ptr<ILineFilter> lineFilter_ = std::unique_ptr<ILineFilter>();
 };
 
 #endif /* LINEFILTERBUILDER_H */

--- a/LineFilter/include/LineFilter/LineFilterInverter.hpp
+++ b/LineFilter/include/LineFilter/LineFilterInverter.hpp
@@ -13,7 +13,7 @@ public:
     virtual ~LineFilterInverter() = default;
 
     // Member methods
-    virtual bool operator()(Line line) const override;
+    virtual bool operator()(Line& line) const override;
 };
 
 #endif /* LINEFILTERINVERTER_H */

--- a/LineFilter/include/LineFilter/LineFilterInverter.hpp
+++ b/LineFilter/include/LineFilter/LineFilterInverter.hpp
@@ -13,7 +13,7 @@ public:
     virtual ~LineFilterInverter() = default;
 
     // Member methods
-    virtual bool operator()(Line& line) const override;
+    virtual bool operator()(const Line& line) const override;
 };
 
 #endif /* LINEFILTERINVERTER_H */

--- a/LineFilter/include/LineFilter/LineFilterInverter.hpp
+++ b/LineFilter/include/LineFilter/LineFilterInverter.hpp
@@ -7,7 +7,7 @@ class LineFilterInverter: public ILineFilterModifier
 {
 public:
     // Constructor
-    LineFilterInverter(ILineFilter* lineFilter);
+    LineFilterInverter(std::unique_ptr<ILineFilter> lineFilter);
 
     // Destructor
     virtual ~LineFilterInverter() = default;

--- a/LineFilter/include/LineFilter/LineMatchFilter.hpp
+++ b/LineFilter/include/LineFilter/LineMatchFilter.hpp
@@ -16,7 +16,7 @@ public:
     ~LineMatchFilter() = default;
 
     // Member methods
-    virtual bool operator()(Line line) const override;
+    virtual bool operator()(Line& line) const override;
 
 protected:
     const std::unique_ptr<const ReferenceLine> lineToMatch_;

--- a/LineFilter/include/LineFilter/LineMatchFilter.hpp
+++ b/LineFilter/include/LineFilter/LineMatchFilter.hpp
@@ -10,7 +10,7 @@ public:
     using ReferenceLine = std::vector<int>;
 
     // Constructors
-    LineMatchFilter(std::unique_ptr<const ReferenceLine> lineToMatch);
+    LineMatchFilter(std::shared_ptr<const ReferenceLine> lineToMatch);
 
     // Destructor
     ~LineMatchFilter() = default;
@@ -19,7 +19,7 @@ public:
     virtual bool operator()(const Line& line) const override;
 
 protected:
-    const std::unique_ptr<const ReferenceLine> lineToMatch_;
+    const std::shared_ptr<const ReferenceLine> lineToMatch_;
 };
 
 #endif /* ILINEMATCHFILTER_H */

--- a/LineFilter/include/LineFilter/LineMatchFilter.hpp
+++ b/LineFilter/include/LineFilter/LineMatchFilter.hpp
@@ -4,19 +4,22 @@
 #include "LineFillFilter.hpp"
 #include "LineEmptyFilter.hpp"
 
-class LineMatchFilter: public LineFillFilter, public LineEmptyFilter
+class LineMatchFilter: public ILineFilter
 {
 public:
     using ReferenceLine = std::vector<int>;
 
     // Constructors
-    LineMatchFilter(const ReferenceLine& lineToMatch);
+    LineMatchFilter(std::unique_ptr<const ReferenceLine> lineToMatch);
 
     // Destructor
     ~LineMatchFilter() = default;
 
     // Member methods
     virtual bool operator()(Line line) const override;
+
+protected:
+    const std::unique_ptr<const ReferenceLine> lineToMatch_;
 };
 
 #endif /* ILINEMATCHFILTER_H */

--- a/LineFilter/include/LineFilter/LineMatchFilter.hpp
+++ b/LineFilter/include/LineFilter/LineMatchFilter.hpp
@@ -16,7 +16,7 @@ public:
     ~LineMatchFilter() = default;
 
     // Member methods
-    virtual bool operator()(Line& line) const override;
+    virtual bool operator()(const Line& line) const override;
 
 protected:
     const std::unique_ptr<const ReferenceLine> lineToMatch_;

--- a/LineFilter/include/LineFilter/SequenceLineFilter.hpp
+++ b/LineFilter/include/LineFilter/SequenceLineFilter.hpp
@@ -16,7 +16,7 @@ public:
     ~SequenceLineFilter() = default;
 
     // Member methods
-    virtual bool operator()(Line line) const override;
+    virtual bool operator()(Line& line) const override;
 protected:
     const NS::Sequence& sequence_;
     const ILineSequencer& sequencer_;

--- a/LineFilter/include/LineFilter/SequenceLineFilter.hpp
+++ b/LineFilter/include/LineFilter/SequenceLineFilter.hpp
@@ -4,22 +4,24 @@
 #include "ILineFilter.hpp"
 #include "ILineSequencer.hpp"
 
+#include <memory>
 #include <Sequence.hpp>
 
 class SequenceLineFilter: public ILineFilter
 {
 public:
     // Contructors
-    SequenceLineFilter(const NS::Sequence& sequence, const ILineSequencer& sequencer);
+    SequenceLineFilter(std::shared_ptr<const NS::Sequence> sequence, std::shared_ptr<const ILineSequencer> sequencer);
 
     // // Destructor
     ~SequenceLineFilter() = default;
 
     // Member methods
     virtual bool operator()(const Line& line) const override;
+
 protected:
-    const NS::Sequence& sequence_;
-    const ILineSequencer& sequencer_;
+    std::shared_ptr<const NS::Sequence> sequence_;
+    std::shared_ptr<const ILineSequencer> sequencer_;
 };
 
 #endif /* SEQUENCERLINEFILTER_H */

--- a/LineFilter/include/LineFilter/SequenceLineFilter.hpp
+++ b/LineFilter/include/LineFilter/SequenceLineFilter.hpp
@@ -16,7 +16,7 @@ public:
     ~SequenceLineFilter() = default;
 
     // Member methods
-    virtual bool operator()(Line& line) const override;
+    virtual bool operator()(const Line& line) const override;
 protected:
     const NS::Sequence& sequence_;
     const ILineSequencer& sequencer_;

--- a/LineFilter/src/ILineFilterModifier.cpp
+++ b/LineFilter/src/ILineFilterModifier.cpp
@@ -8,5 +8,5 @@ ILineFilterModifier::ILineFilterModifier(ILineFilter* lineFilter)
 
 ILineFilterModifier::~ILineFilterModifier()
 {
-    delete lineFilter_;
+
 }

--- a/LineFilter/src/ILineFilterModifier.cpp
+++ b/LineFilter/src/ILineFilterModifier.cpp
@@ -1,7 +1,7 @@
 #include "ILineFilterModifier.hpp"
 
-ILineFilterModifier::ILineFilterModifier(ILineFilter* lineFilter)
-    : lineFilter_{lineFilter}
+ILineFilterModifier::ILineFilterModifier(std::unique_ptr<ILineFilter> lineFilter)
+    : lineFilter_(std::move(lineFilter))
 {
     
 }

--- a/LineFilter/src/LineEmptyFilter.cpp
+++ b/LineFilter/src/LineEmptyFilter.cpp
@@ -3,8 +3,8 @@
 #include <stdexcept>
 #include <string>
 
-LineEmptyFilter::LineEmptyFilter(const ReferenceLine& lineToMatch)
-    : lineToMatch_(lineToMatch)
+LineEmptyFilter::LineEmptyFilter(std::unique_ptr<const ReferenceLine> lineToMatch)
+    : lineToMatch_(std::move(lineToMatch))
 {
 
 }
@@ -12,16 +12,16 @@ LineEmptyFilter::LineEmptyFilter(const ReferenceLine& lineToMatch)
 bool LineEmptyFilter::operator()(LineEmptyFilter::Line line) const
 {
     auto lineSize = line.size();
-    auto lineToMatchSize = lineToMatch_.size();
+    auto lineToMatchSize = lineToMatch_->size();
 
     if(lineSize != lineToMatchSize)
         throw(std::logic_error(std::string("Tested line is not the same length as reference line; "
                                             "tested line as length: ") + std::to_string(line.size()) + 
                                             std::string(" and reference line has a length of: ") +
-                                            std::to_string(lineToMatch_.size())));
+                                            std::to_string(lineToMatch_->size())));
 
     for(auto i = 0; i < lineSize; ++i){
-        if(lineToMatch_[i] == 0 && line[i] != 0)
+        if(lineToMatch_->at(i) == 0 && line[i] != 0)
             return false;
     }
 

--- a/LineFilter/src/LineEmptyFilter.cpp
+++ b/LineFilter/src/LineEmptyFilter.cpp
@@ -9,7 +9,7 @@ LineEmptyFilter::LineEmptyFilter(std::unique_ptr<const ReferenceLine> lineToMatc
 
 }
 
-bool LineEmptyFilter::operator()(LineEmptyFilter::Line& line) const
+bool LineEmptyFilter::operator()(const LineEmptyFilter::Line& line) const
 {
     auto lineSize = line.size();
     auto lineToMatchSize = lineToMatch_->size();

--- a/LineFilter/src/LineEmptyFilter.cpp
+++ b/LineFilter/src/LineEmptyFilter.cpp
@@ -9,7 +9,7 @@ LineEmptyFilter::LineEmptyFilter(std::unique_ptr<const ReferenceLine> lineToMatc
 
 }
 
-bool LineEmptyFilter::operator()(LineEmptyFilter::Line line) const
+bool LineEmptyFilter::operator()(LineEmptyFilter::Line& line) const
 {
     auto lineSize = line.size();
     auto lineToMatchSize = lineToMatch_->size();

--- a/LineFilter/src/LineEmptyFilter.cpp
+++ b/LineFilter/src/LineEmptyFilter.cpp
@@ -3,8 +3,8 @@
 #include <stdexcept>
 #include <string>
 
-LineEmptyFilter::LineEmptyFilter(std::unique_ptr<const ReferenceLine> lineToMatch)
-    : lineToMatch_(std::move(lineToMatch))
+LineEmptyFilter::LineEmptyFilter(std::shared_ptr<const ReferenceLine> lineToMatch)
+    : lineToMatch_(lineToMatch)
 {
 
 }

--- a/LineFilter/src/LineFillFilter.cpp
+++ b/LineFilter/src/LineFillFilter.cpp
@@ -3,8 +3,8 @@
 #include <stdexcept>
 #include <string>
 
-LineFillFilter::LineFillFilter(std::unique_ptr<const ReferenceLine> lineToMatch)
-    : lineToMatch_(std::move(lineToMatch))
+LineFillFilter::LineFillFilter(std::shared_ptr<const ReferenceLine> lineToMatch)
+    : lineToMatch_(lineToMatch)
 {
 
 }

--- a/LineFilter/src/LineFillFilter.cpp
+++ b/LineFilter/src/LineFillFilter.cpp
@@ -9,7 +9,7 @@ LineFillFilter::LineFillFilter(std::unique_ptr<const ReferenceLine> lineToMatch)
 
 }
 
-bool LineFillFilter::operator()(LineFillFilter::Line& line) const
+bool LineFillFilter::operator()(const LineFillFilter::Line& line) const
 {
     auto lineSize = line.size();
     auto lineToMatchSize = lineToMatch_->size();

--- a/LineFilter/src/LineFillFilter.cpp
+++ b/LineFilter/src/LineFillFilter.cpp
@@ -3,8 +3,8 @@
 #include <stdexcept>
 #include <string>
 
-LineFillFilter::LineFillFilter(const ReferenceLine& lineToMatch)
-    : lineToMatch_(lineToMatch)
+LineFillFilter::LineFillFilter(std::unique_ptr<const ReferenceLine> lineToMatch)
+    : lineToMatch_(std::move(lineToMatch))
 {
 
 }
@@ -12,16 +12,16 @@ LineFillFilter::LineFillFilter(const ReferenceLine& lineToMatch)
 bool LineFillFilter::operator()(LineFillFilter::Line line) const
 {
     auto lineSize = line.size();
-    auto lineToMatchSize = lineToMatch_.size();
+    auto lineToMatchSize = lineToMatch_->size();
 
     if(lineSize != lineToMatchSize)
         throw(std::logic_error(std::string("Tested line is not the same length as reference line; "
                                             "tested line as length: ") + std::to_string(line.size()) + 
                                             std::string(" and reference line has a length of: ") +
-                                            std::to_string(lineToMatch_.size())));
+                                            std::to_string(lineToMatch_->size())));
 
     for(auto i = 0; i < lineSize; ++i){
-        if(lineToMatch_[i] == 1 && line[i] != 1)
+        if(lineToMatch_->at(i) == 1 && line[i] != 1)
             return false;
     }
 

--- a/LineFilter/src/LineFillFilter.cpp
+++ b/LineFilter/src/LineFillFilter.cpp
@@ -9,7 +9,7 @@ LineFillFilter::LineFillFilter(std::unique_ptr<const ReferenceLine> lineToMatch)
 
 }
 
-bool LineFillFilter::operator()(LineFillFilter::Line line) const
+bool LineFillFilter::operator()(LineFillFilter::Line& line) const
 {
     auto lineSize = line.size();
     auto lineToMatchSize = lineToMatch_->size();

--- a/LineFilter/src/LineFilterBuilder.cpp
+++ b/LineFilter/src/LineFilterBuilder.cpp
@@ -5,12 +5,12 @@
 
 #include <stdexcept>
 
-LineFilterBuilder& LineFilterBuilder::sequenceLineFilter(NS::Sequence sequence, ILineSequencer& sequencer)
+LineFilterBuilder& LineFilterBuilder::sequenceLineFilter(std::shared_ptr<const NS::Sequence> sequence, std::shared_ptr<const ILineSequencer> sequencer)
 {
     if(lineFilter_)
         throw(std::logic_error("Base line filter has already been created, cannot create SequenceLineFilter"));
     
-    lineFilter_ = new SequenceLineFilter(sequence, sequencer);
+    lineFilter_ = std::make_unique<SequenceLineFilter>(sequence, sequencer);
 
     return *this;
 }
@@ -20,27 +20,22 @@ LineFilterBuilder& LineFilterBuilder::lineFilterInverter()
     if(!lineFilter_)
         throw(std::logic_error("No base line filter has been created, cannot create LineFilterInverter"));
 
-    lineFilter_ = new LineFilterInverter(lineFilter_);
+    lineFilter_ = std::make_unique<LineFilterInverter>(std::move(lineFilter_));
 
     return *this;
 }
 
-ILineFilter* LineFilterBuilder::makeLineFilter()
+std::unique_ptr<ILineFilter> LineFilterBuilder::makeLineFilter()
 {
     if(!lineFilter_)
         throw(std::logic_error("No line filter has been created"));
 
-    ILineFilter* lineFilterTemp= lineFilter_;
-    lineFilter_ = nullptr;
-
-    return lineFilterTemp;
+    return std::move(lineFilter_);
 }
 
 LineFilterBuilder& LineFilterBuilder::reset()
 {
-    delete lineFilter_;
-
-    lineFilter_ = nullptr;
+    lineFilter_.reset(nullptr);
 
     return *this;
 }

--- a/LineFilter/src/LineFilterInverter.cpp
+++ b/LineFilter/src/LineFilterInverter.cpp
@@ -6,7 +6,7 @@ LineFilterInverter::LineFilterInverter(std::unique_ptr<ILineFilter> lineFilter)
 
 }
 
-bool LineFilterInverter::operator()(Line& line) const
+bool LineFilterInverter::operator()(const Line& line) const
 {
     return !(*lineFilter_)(line);
 }

--- a/LineFilter/src/LineFilterInverter.cpp
+++ b/LineFilter/src/LineFilterInverter.cpp
@@ -6,7 +6,7 @@ LineFilterInverter::LineFilterInverter(std::unique_ptr<ILineFilter> lineFilter)
 
 }
 
-bool LineFilterInverter::operator()(Line line) const
+bool LineFilterInverter::operator()(Line& line) const
 {
     return !(*lineFilter_)(line);
 }

--- a/LineFilter/src/LineFilterInverter.cpp
+++ b/LineFilter/src/LineFilterInverter.cpp
@@ -1,7 +1,7 @@
 #include "LineFilterInverter.hpp"
 
-LineFilterInverter::LineFilterInverter(ILineFilter* lineFilter)
-    : ILineFilterModifier(lineFilter)
+LineFilterInverter::LineFilterInverter(std::unique_ptr<ILineFilter> lineFilter)
+    : ILineFilterModifier(std::move(lineFilter))
 {
 
 }

--- a/LineFilter/src/LineMatchFilter.cpp
+++ b/LineFilter/src/LineMatchFilter.cpp
@@ -21,7 +21,7 @@ bool LineMatchFilter::operator()(const LineMatchFilter::Line& line) const
                                             std::to_string(lineToMatch_->size())));
 
     for(auto i = 0; i < lineSize; ++i){
-        if(lineToMatch_->at(i) == line[i] || line[i] == -1)
+        if(lineToMatch_->at(i) != -1 && lineToMatch_->at(i) != line[i])
             return false;
     }
 

--- a/LineFilter/src/LineMatchFilter.cpp
+++ b/LineFilter/src/LineMatchFilter.cpp
@@ -3,13 +3,27 @@
 #include <stdexcept>
 #include <string>
 
-LineMatchFilter::LineMatchFilter(const ReferenceLine& lineToMatch)
-    : LineFillFilter(lineToMatch), LineEmptyFilter(lineToMatch)
+LineMatchFilter::LineMatchFilter(std::unique_ptr<const ReferenceLine> lineToMatch)
+    : lineToMatch_(std::move(lineToMatch))
 {
 
 }
 
 bool LineMatchFilter::operator()(LineMatchFilter::Line line) const
 {
-    return LineFillFilter::operator()(line) && LineEmptyFilter::operator()(line);
+    auto lineSize = line.size();
+    auto lineToMatchSize = lineToMatch_->size();
+
+    if(lineSize != lineToMatchSize)
+        throw(std::logic_error(std::string("Tested line is not the same length as reference line; "
+                                            "tested line as length: ") + std::to_string(line.size()) + 
+                                            std::string(" and reference line has a length of: ") +
+                                            std::to_string(lineToMatch_->size())));
+
+    for(auto i = 0; i < lineSize; ++i){
+        if(lineToMatch_->at(i) == line[i] || line[i] == -1)
+            return false;
+    }
+
+    return true;
 }

--- a/LineFilter/src/LineMatchFilter.cpp
+++ b/LineFilter/src/LineMatchFilter.cpp
@@ -9,7 +9,7 @@ LineMatchFilter::LineMatchFilter(std::unique_ptr<const ReferenceLine> lineToMatc
 
 }
 
-bool LineMatchFilter::operator()(LineMatchFilter::Line& line) const
+bool LineMatchFilter::operator()(const LineMatchFilter::Line& line) const
 {
     auto lineSize = line.size();
     auto lineToMatchSize = lineToMatch_->size();

--- a/LineFilter/src/LineMatchFilter.cpp
+++ b/LineFilter/src/LineMatchFilter.cpp
@@ -9,7 +9,7 @@ LineMatchFilter::LineMatchFilter(std::unique_ptr<const ReferenceLine> lineToMatc
 
 }
 
-bool LineMatchFilter::operator()(LineMatchFilter::Line line) const
+bool LineMatchFilter::operator()(LineMatchFilter::Line& line) const
 {
     auto lineSize = line.size();
     auto lineToMatchSize = lineToMatch_->size();

--- a/LineFilter/src/LineMatchFilter.cpp
+++ b/LineFilter/src/LineMatchFilter.cpp
@@ -3,8 +3,8 @@
 #include <stdexcept>
 #include <string>
 
-LineMatchFilter::LineMatchFilter(std::unique_ptr<const ReferenceLine> lineToMatch)
-    : lineToMatch_(std::move(lineToMatch))
+LineMatchFilter::LineMatchFilter(std::shared_ptr<const ReferenceLine> lineToMatch)
+    : lineToMatch_(lineToMatch)
 {
 
 }

--- a/LineFilter/src/SequenceLineFilter.cpp
+++ b/LineFilter/src/SequenceLineFilter.cpp
@@ -1,6 +1,6 @@
 #include "SequenceLineFilter.hpp"
 
-SequenceLineFilter::SequenceLineFilter(const NS::Sequence& sequence, const ILineSequencer& sequencer)
+SequenceLineFilter::SequenceLineFilter(std::shared_ptr<const NS::Sequence> sequence, std::shared_ptr<const ILineSequencer> sequencer)
     : sequence_{sequence}, sequencer_{sequencer}
 {
 
@@ -8,5 +8,5 @@ SequenceLineFilter::SequenceLineFilter(const NS::Sequence& sequence, const ILine
 
 bool SequenceLineFilter::operator()(const Line& line) const
 {
-    return sequencer_(line) == sequence_;
+    return (*sequencer_)(line) == *sequence_;
 }

--- a/LineFilter/src/SequenceLineFilter.cpp
+++ b/LineFilter/src/SequenceLineFilter.cpp
@@ -6,7 +6,7 @@ SequenceLineFilter::SequenceLineFilter(const NS::Sequence& sequence, const ILine
 
 }
 
-bool SequenceLineFilter::operator()(Line& line) const
+bool SequenceLineFilter::operator()(const Line& line) const
 {
     return sequencer_(line) == sequence_;
 }

--- a/LineFilter/src/SequenceLineFilter.cpp
+++ b/LineFilter/src/SequenceLineFilter.cpp
@@ -6,7 +6,7 @@ SequenceLineFilter::SequenceLineFilter(const NS::Sequence& sequence, const ILine
 
 }
 
-bool SequenceLineFilter::operator()(Line line) const
+bool SequenceLineFilter::operator()(Line& line) const
 {
     return sequencer_(line) == sequence_;
 }

--- a/LineFilter/tests/LineFilter_test.cpp
+++ b/LineFilter/tests/LineFilter_test.cpp
@@ -10,6 +10,7 @@
 
 #include <LineGeneratorBuilder.hpp>
 
+#include <memory>
 #include <vector>
 #include <utility>
 
@@ -27,73 +28,73 @@ protected:
         // Rows
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {0, 1, 0, 1, 0},
-                    {1, 1}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1, 1}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 1, 1, 1, 1},
-                    {5}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({5}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 1, 1, 1, 1},
-                    {5}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({5}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {0, 1, 1, 1, 0},
-                    {3}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({3}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {0, 0, 1, 0, 0},
-                    {1}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1}))
                 )
             );
         // Columns
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {0, 1, 1, 0, 0},
-                    {2}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({2}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 1, 1, 1, 0},
-                    {4}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({4}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {0, 1, 1, 1, 1},
-                    {4}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({4}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 1, 1, 1, 0},
-                    {4}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({4}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {0, 1, 1, 0, 0},
-                    {2}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({2}))
                 )
             );
 
@@ -101,152 +102,152 @@ protected:
         // Rows
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 1, 0, 0, 1, 0, 0, 1, 1, 1},
-                    {2, 1, 3}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({2, 1, 3}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 0, 0, 0, 0, 0, 1, 0, 1, 1},
-                    {1, 1, 2}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1, 1, 2}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr <NS::Sequence>>(
                     {1, 0, 0, 0, 0, 0, 1, 0, 1, 1},
-                    {1, 1, 2}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1, 1, 2}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 0, 0, 0, 0, 0, 0, 0, 1, 1},
-                    {1, 2}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1, 2}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 1, 0, 0, 0, 0, 0, 1, 1, 1},
-                    {2, 3}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({2, 3}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 1, 1, 0, 0, 0, 1, 1, 1, 1},
-                    {3, 4}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({3, 4}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 1, 1, 1, 0, 1, 1, 1, 0, 1},
-                    {4, 3, 1}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({4, 3, 1}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 0, 1, 1, 1, 1, 1, 0, 1, 0},
-                    {1, 5, 1}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1, 5, 1}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {0, 1, 0, 1, 1, 0, 1, 1, 0, 1},
-                    {1, 2, 2, 1}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1, 2, 2, 1}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 0, 1, 1, 0, 1, 0, 1, 1, 1},
-                    {1, 2, 1, 3}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1, 2, 1, 3}))
                 )
             );
         // Columns
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 1, 1, 1, 1, 1, 1, 1, 0, 1},
-                    {8, 1}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({8, 1}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 0, 0, 0, 1, 1, 1, 0, 1, 0},
-                    {1, 3, 1}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1, 3, 1}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {0, 0, 0, 0, 0, 1, 1, 1, 0, 1},
-                    {3, 1}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({3, 1}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {0, 0, 0, 0, 0, 0, 1, 1, 1, 1},
-                    {4}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({4}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 0, 0, 0, 0, 0, 0, 1, 1, 0},
-                    {1, 2}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1, 2}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {0, 0, 0, 0, 0, 0, 1, 1, 0, 1},
-                    {2, 1}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({2, 1}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {0, 1, 1, 0, 0, 1, 1, 1, 1, 0},
-                    {2, 4}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({2, 4}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 0, 0, 0, 1, 1, 1, 0, 1, 1},
-                    {1, 3, 2}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1, 3, 2}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 1, 1, 1, 1, 1, 0, 1, 0, 1},
-                    {6, 1, 1}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({6, 1, 1}))
                 )
             );
         testLinesSequences
             .push_back(
-                std::pair<ILineSequencer::Line, NS::Sequence>(
+                std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>(
                     {1, 1, 1, 1, 1, 1, 1, 0, 1, 1},
-                    {7, 2}
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({7, 2}))
                 )
             );
     }
 
-    std::vector<std::pair<ILineSequencer::Line, NS::Sequence>> testLinesSequences;
+    std::vector<std::pair<ILineSequencer::Line, std::shared_ptr<NS::Sequence>>> testLinesSequences;
 };
 
 TEST_F(SequenceLineFilterTest, SequenceLineFilter) {
-    FSTLineSequencer sequencer;
+    std::shared_ptr<FSTLineSequencer> sequencer = std::make_shared<FSTLineSequencer>();
 
     for(const auto& lineSequence : testLinesSequences) {
         EXPECT_TRUE(SequenceLineFilter(lineSequence.second, sequencer)(lineSequence.first));
@@ -254,32 +255,30 @@ TEST_F(SequenceLineFilterTest, SequenceLineFilter) {
 }
 
 TEST_F(SequenceLineFilterTest, LineFilterInverter) {
-    FSTLineSequencer sequencer;
+    std::shared_ptr<FSTLineSequencer> sequencer = std::make_shared<FSTLineSequencer>();
 
     for(const auto& lineSequence : testLinesSequences) {
-        EXPECT_FALSE(LineFilterInverter(new SequenceLineFilter(lineSequence.second, sequencer))(lineSequence.first));
+        EXPECT_FALSE(LineFilterInverter(std::make_unique<SequenceLineFilter>(lineSequence.second, sequencer))(lineSequence.first));
     }
 }
 
 TEST_F(SequenceLineFilterTest, LineFilterBuilder) {
-    FSTLineSequencer sequencer;
+    std::shared_ptr<FSTLineSequencer> sequencer = std::make_shared<FSTLineSequencer>();
     LineFilterBuilder builder;
 
     for(const auto& lineSequence : testLinesSequences) {
-        ILineFilter* filter = builder.sequenceLineFilter(lineSequence.second, sequencer).makeLineFilter();
+        std::unique_ptr<ILineFilter> filter = builder.sequenceLineFilter(lineSequence.second, sequencer).makeLineFilter();
 
         EXPECT_TRUE((*filter)(lineSequence.first));
 
-        delete filter;
         builder.reset();
     }
 
     for(const auto& lineSequence : testLinesSequences) {
-        ILineFilter* filter = builder.sequenceLineFilter(lineSequence.second, sequencer).lineFilterInverter().makeLineFilter();
+        std::unique_ptr<ILineFilter> filter = builder.sequenceLineFilter(lineSequence.second, sequencer).lineFilterInverter().makeLineFilter();
 
         EXPECT_FALSE((*filter)(lineSequence.first));
 
-        delete filter;
         builder.reset();
     }
 }
@@ -303,7 +302,7 @@ protected:
 
 TEST_F(LineFillFilterTest, AllNonDefinedLine)
 {
-    LineFillFilter::ReferenceLine lineToMatch({-1, -1, -1});
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, -1, -1}));
     LineFillFilter fillFilter(lineToMatch);
 
     for(const auto& line: lines)
@@ -314,7 +313,7 @@ TEST_F(LineFillFilterTest, AllNonDefinedLine)
 
 TEST_F(LineFillFilterTest, IgnoreEmpty)
 {
-    LineFillFilter::ReferenceLine lineToMatch({0, 0, 0});
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch({0, 0, 0});
     LineFillFilter fillFilter(lineToMatch);
 
     for(const auto& line: lines)
@@ -325,13 +324,13 @@ TEST_F(LineFillFilterTest, IgnoreEmpty)
 
 TEST_F(LineFillFilterTest, FillDefinedLine)
 {
-    LineFillFilter::ReferenceLine lineToMatch1({-1, -1, 1});
-    LineFillFilter::ReferenceLine lineToMatch2({-1, 1, -1});
-    LineFillFilter::ReferenceLine lineToMatch3({-1, 1, 1});
-    LineFillFilter::ReferenceLine lineToMatch4({1, -1, -1});
-    LineFillFilter::ReferenceLine lineToMatch5({1, -1, 1});
-    LineFillFilter::ReferenceLine lineToMatch6({1, 1, -1});
-    LineFillFilter::ReferenceLine lineToMatch7({1, 1, 1});
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch1 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, -1, 1}));
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch2 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, 1, -1}));
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch3 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, 1, 1}));
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch4 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, -1, -1}));
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch5 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, -1, 1}));
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch6 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, 1, -1}));
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch7 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, 1, 1}));
     
     LineFillFilter fillFilter1(lineToMatch1);
     LineFillFilter fillFilter2(lineToMatch2);
@@ -431,7 +430,7 @@ protected:
 
 TEST_F(LineEmptyFilterTest, AllNonDefinedLine)
 {
-    LineEmptyFilter::ReferenceLine lineToMatch({-1, -1, -1});
+    std::shared_ptr<LineEmptyFilter::ReferenceLine> lineToMatch = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, -1, -1}));
     LineEmptyFilter emptyFilter(lineToMatch);
 
     for(const auto& line: lines)
@@ -442,7 +441,7 @@ TEST_F(LineEmptyFilterTest, AllNonDefinedLine)
 
 TEST_F(LineEmptyFilterTest, IgnoreFilled)
 {
-    LineEmptyFilter::ReferenceLine lineToMatch({1, 1, 1});
+    std::shared_ptr<LineEmptyFilter::ReferenceLine> lineToMatch = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, 1, 1}));
     LineEmptyFilter emptyFilter(lineToMatch);
 
     for(const auto& line: lines)
@@ -453,13 +452,13 @@ TEST_F(LineEmptyFilterTest, IgnoreFilled)
 
 TEST_F(LineEmptyFilterTest, EmptyDefinedLine)
 {
-    LineEmptyFilter::ReferenceLine lineToMatch1({-1, -1, 0});
-    LineEmptyFilter::ReferenceLine lineToMatch2({-1, 0, -1});
-    LineEmptyFilter::ReferenceLine lineToMatch3({-1, 0, 0});
-    LineEmptyFilter::ReferenceLine lineToMatch4({0, -1, -1});
-    LineEmptyFilter::ReferenceLine lineToMatch5({0, -1, 0});
-    LineEmptyFilter::ReferenceLine lineToMatch6({0, 0, -1});
-    LineEmptyFilter::ReferenceLine lineToMatch7({0, 0, 0});
+    std::shared_ptr<LineEmptyFilter::ReferenceLine> lineToMatch1 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, -1, 0}));
+    std::shared_ptr<LineEmptyFilter::ReferenceLine> lineToMatch2 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, 0, -1}));
+    std::shared_ptr<LineEmptyFilter::ReferenceLine> lineToMatch3 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, 0, 0}));
+    std::shared_ptr<LineEmptyFilter::ReferenceLine> lineToMatch4 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({0, -1, -1}));
+    std::shared_ptr<LineEmptyFilter::ReferenceLine> lineToMatch5 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({0, -1, 0}));
+    std::shared_ptr<LineEmptyFilter::ReferenceLine> lineToMatch6 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({0, 0, -1}));
+    std::shared_ptr<LineEmptyFilter::ReferenceLine> lineToMatch7 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({0, 0, 0}));
     
     LineEmptyFilter emptyFilter1(lineToMatch1);
     LineEmptyFilter emptyFilter2(lineToMatch2);
@@ -559,7 +558,7 @@ protected:
 
 TEST_F(LineMatchFilterTest, AllNonDefinedLine)
 {
-    LineMatchFilter::ReferenceLine lineToMatch({-1, -1, -1});
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, -1, -1}));
     LineMatchFilter matchFilter(lineToMatch);
 
     for(const auto& line: lines)
@@ -570,13 +569,13 @@ TEST_F(LineMatchFilterTest, AllNonDefinedLine)
 
 TEST_F(LineMatchFilterTest, FillDefinedLine)
 {
-    LineFillFilter::ReferenceLine lineToMatch1({-1, -1, 1});
-    LineFillFilter::ReferenceLine lineToMatch2({-1, 1, -1});
-    LineFillFilter::ReferenceLine lineToMatch3({-1, 1, 1});
-    LineFillFilter::ReferenceLine lineToMatch4({1, -1, -1});
-    LineFillFilter::ReferenceLine lineToMatch5({1, -1, 1});
-    LineFillFilter::ReferenceLine lineToMatch6({1, 1, -1});
-    LineFillFilter::ReferenceLine lineToMatch7({1, 1, 1});
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch1 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, -1, 1}));
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch2 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, 1, -1}));
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch3 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, 1, 1}));
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch4 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, -1, -1}));
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch5 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, -1, 1}));
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch6 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, 1, -1}));
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch7 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, 1, 1}));
     
     LineFillFilter matchFilter1(lineToMatch1);
     LineFillFilter matchFilter2(lineToMatch2);
@@ -659,13 +658,13 @@ TEST_F(LineMatchFilterTest, FillDefinedLine)
 
 TEST_F(LineMatchFilterTest, EmptyDefinedLine)
 {
-    LineMatchFilter::ReferenceLine lineToMatch1({-1, -1, 0});
-    LineMatchFilter::ReferenceLine lineToMatch2({-1, 0, -1});
-    LineMatchFilter::ReferenceLine lineToMatch3({-1, 0, 0});
-    LineMatchFilter::ReferenceLine lineToMatch4({0, -1, -1});
-    LineMatchFilter::ReferenceLine lineToMatch5({0, -1, 0});
-    LineMatchFilter::ReferenceLine lineToMatch6({0, 0, -1});
-    LineMatchFilter::ReferenceLine lineToMatch7({0, 0, 0});
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch1 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, -1, 0}));
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch2 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, 0, -1}));
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch3 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({-1, 0, 0}));
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch4 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({0, -1, -1}));
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch5 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({0, -1, 0}));
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch6 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({0, 0, -1}));
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch7 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({0, 0, 0}));
     
     LineMatchFilter matchFilter1(lineToMatch1);
     LineMatchFilter matchFilter2(lineToMatch2);
@@ -748,13 +747,13 @@ TEST_F(LineMatchFilterTest, EmptyDefinedLine)
 
 TEST_F(LineMatchFilterTest, FullyDefinedLine)
 {
-    LineMatchFilter::ReferenceLine lineToMatch1({0, 0, 1});
-    LineMatchFilter::ReferenceLine lineToMatch2({0, 1, 0});
-    LineMatchFilter::ReferenceLine lineToMatch3({0, 1, 1});
-    LineMatchFilter::ReferenceLine lineToMatch4({1, 0, 0});
-    LineMatchFilter::ReferenceLine lineToMatch5({1, 0, 1});
-    LineMatchFilter::ReferenceLine lineToMatch6({1, 1, 0});
-    LineMatchFilter::ReferenceLine lineToMatch7({1, 1, 1});
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch1 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({0, 0, 1}));
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch2 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({0, 1, 0}));
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch3 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({0, 1, 1}));
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch4 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, 0, 0}));
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch5 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, 0, 1}));
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch6 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, 1, 0}));
+    std::shared_ptr<LineMatchFilter::ReferenceLine> lineToMatch7 = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({1, 1, 1}));
     
     LineMatchFilter matchFilter1(lineToMatch1);
     LineMatchFilter matchFilter2(lineToMatch2);

--- a/LineFilter/tests/LineFilter_test.cpp
+++ b/LineFilter/tests/LineFilter_test.cpp
@@ -293,8 +293,6 @@ protected:
         auto generator = generatorBuilder.allPossibleLinesGenerator(3).makeLineGenerator();
 
         lines = generator->generateLines();
-
-        delete generator;
     }
 
     std::vector<ILineFilter::Line> lines;
@@ -313,7 +311,7 @@ TEST_F(LineFillFilterTest, AllNonDefinedLine)
 
 TEST_F(LineFillFilterTest, IgnoreEmpty)
 {
-    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch({0, 0, 0});
+    std::shared_ptr<LineFillFilter::ReferenceLine> lineToMatch = std::make_shared<LineFillFilter::ReferenceLine>(std::initializer_list<int>({0, 0, 0}));
     LineFillFilter fillFilter(lineToMatch);
 
     for(const auto& line: lines)
@@ -421,8 +419,6 @@ protected:
         auto generator = generatorBuilder.allPossibleLinesGenerator(3).makeLineGenerator();
 
         lines = generator->generateLines();
-
-        delete generator;
     }
 
     std::vector<ILineFilter::Line> lines;
@@ -549,8 +545,6 @@ protected:
         auto generator = generatorBuilder.allPossibleLinesGenerator(3).makeLineGenerator();
 
         lines = generator->generateLines();
-
-        delete generator;
     }
 
     std::vector<ILineFilter::Line> lines;

--- a/LineGenerator/include/LineGenerator/ILineGeneratorModifier.hpp
+++ b/LineGenerator/include/LineGenerator/ILineGeneratorModifier.hpp
@@ -3,19 +3,21 @@
 
 #include "ILineGenerator.hpp"
 
+#include <memory>
+
 namespace NS
 {
     class ILineGeneratorModifier: public ILineGenerator
     {
     public:
         // Constructors
-        ILineGeneratorModifier(ILineGenerator* lineGenerator);
+        ILineGeneratorModifier(std::unique_ptr<ILineGenerator> lineGenerator);
 
         // Destructor
         ~ILineGeneratorModifier();
 
     protected:
-        ILineGenerator* lineGenerator_;
+        std::unique_ptr<ILineGenerator> lineGenerator_;
     };
 }
 

--- a/LineGenerator/include/LineGenerator/LineGeneratorBuilder.hpp
+++ b/LineGenerator/include/LineGenerator/LineGeneratorBuilder.hpp
@@ -4,6 +4,8 @@
 #include "ILineGenerator.hpp"
 #include "ILineFilter.hpp"
 
+#include <memory>
+
 namespace NS
 {
     class LineGeneratorBuilder
@@ -13,23 +15,23 @@ namespace NS
         LineGeneratorBuilder() = default;
 
         // Destructor
-        virtual ~LineGeneratorBuilder();
+        virtual ~LineGeneratorBuilder() = default;
 
         //Building methods
         // Base line generators
         LineGeneratorBuilder& allPossibleLinesGenerator(unsigned int nbBoxes);
 
         //Line generator modifiers
-        LineGeneratorBuilder& lineGeneratorFilter(ILineFilter* lineFilter);
+        LineGeneratorBuilder& lineGeneratorFilter(std::shared_ptr<ILineFilter> lineFilter);
 
         // Make line filter
-        ILineGenerator* makeLineGenerator();
+        std::unique_ptr<ILineGenerator> makeLineGenerator();
 
         // Reset builder
         LineGeneratorBuilder& reset();
 
     protected:
-        NS::ILineGenerator* lineGenerator_ = nullptr;
+        std::unique_ptr<NS::ILineGenerator> lineGenerator_ = std::unique_ptr<NS::ILineGenerator>();
     };
 }
 #endif /* LINEGENERATORBUILDER_H */

--- a/LineGenerator/include/LineGenerator/LineGeneratorFilter.hpp
+++ b/LineGenerator/include/LineGenerator/LineGeneratorFilter.hpp
@@ -5,13 +5,15 @@
 
 #include "ILineFilter.hpp"
 
+#include <memory>
+
 namespace NS
 {
     class LineGeneratorFilter: public ILineGeneratorModifier
     {
     public:
         // Constructor
-        LineGeneratorFilter(ILineFilter* lineFilter, ILineGenerator* lineGenerator);
+        LineGeneratorFilter(std::shared_ptr<ILineFilter> lineFilter, std::unique_ptr<ILineGenerator> lineGenerator);
 
         // Destructor
         ~LineGeneratorFilter();
@@ -19,7 +21,7 @@ namespace NS
         virtual std::vector<Line> generateLines() override;
 
     protected:
-        ILineFilter* lineFilter_;
+        std::shared_ptr<ILineFilter> lineFilter_;
     };
 }
 

--- a/LineGenerator/src/ILineGeneratorModifier.cpp
+++ b/LineGenerator/src/ILineGeneratorModifier.cpp
@@ -1,12 +1,12 @@
 #include "ILineGeneratorModifier.hpp"
 
-NS::ILineGeneratorModifier::ILineGeneratorModifier(ILineGenerator* lineGenerator)
-    : lineGenerator_{lineGenerator}
+NS::ILineGeneratorModifier::ILineGeneratorModifier(std::unique_ptr<ILineGenerator> lineGenerator)
+    : lineGenerator_(std::move(lineGenerator))
 {
 
 }
 
 NS::ILineGeneratorModifier::~ILineGeneratorModifier()
 {
-    delete lineGenerator_;
+    
 }

--- a/LineGenerator/src/LineGeneratorBuilder.cpp
+++ b/LineGenerator/src/LineGeneratorBuilder.cpp
@@ -5,47 +5,37 @@
 
 #include <stdexcept>
 
-NS::LineGeneratorBuilder::~LineGeneratorBuilder()
-{
-    delete lineGenerator_;
-}
-
 NS::LineGeneratorBuilder& NS::LineGeneratorBuilder::allPossibleLinesGenerator(unsigned int nbBoxes)
 {
     if(lineGenerator_)
         throw(std::logic_error("Base line generator has already been created, cannot create AllPossibleLinesGenerator"));
     
-    lineGenerator_ = new NS::AllPossibleLinesGenerator(nbBoxes);
+    lineGenerator_ = std::make_unique<NS::AllPossibleLinesGenerator>(nbBoxes);
 
     return *this;
 }
 
-NS::LineGeneratorBuilder& NS::LineGeneratorBuilder::lineGeneratorFilter(ILineFilter* lineFilter)
+NS::LineGeneratorBuilder& NS::LineGeneratorBuilder::lineGeneratorFilter(std::shared_ptr<ILineFilter> lineFilter)
 {
     if(!lineGenerator_)
         throw(std::logic_error("No base line generator has been created, cannot create LineGeneratorFilter"));
 
-    lineGenerator_ = new NS::LineGeneratorFilter(lineFilter, lineGenerator_);
+    lineGenerator_ = std::make_unique<NS::LineGeneratorFilter>(lineFilter, std::move(lineGenerator_));
 
     return *this;
 }
 
-NS::ILineGenerator* NS::LineGeneratorBuilder::makeLineGenerator()
+std::unique_ptr<NS::ILineGenerator> NS::LineGeneratorBuilder::makeLineGenerator()
 {
     if(!lineGenerator_)
         throw(std::logic_error("No line generator has been created"));
 
-    ILineGenerator* lineGeneratorTemp= lineGenerator_;
-    lineGenerator_ = nullptr;
-
-    return lineGeneratorTemp;
+    return std::move(lineGenerator_);
 }
 
 NS::LineGeneratorBuilder& NS::LineGeneratorBuilder::reset()
 {
-    delete lineGenerator_;
-
-    lineGenerator_ = nullptr;
+    lineGenerator_.reset(nullptr);
 
     return *this;
 }

--- a/LineGenerator/src/LineGeneratorFilter.cpp
+++ b/LineGenerator/src/LineGeneratorFilter.cpp
@@ -2,15 +2,15 @@
 
 #include <algorithm>
 
-NS::LineGeneratorFilter::LineGeneratorFilter(ILineFilter* lineFilter, ILineGenerator* lineGenerator)
-    : ILineGeneratorModifier{lineGenerator}, lineFilter_{lineFilter}
+NS::LineGeneratorFilter::LineGeneratorFilter(std::shared_ptr<ILineFilter> lineFilter, std::unique_ptr<ILineGenerator> lineGenerator)
+    : ILineGeneratorModifier(std::move(lineGenerator)), lineFilter_(lineFilter)
 {
 
 }
 
 NS::LineGeneratorFilter::~LineGeneratorFilter()
 {
-    delete lineFilter_;
+    
 }
 
 std::vector<NS::ILineGenerator::Line> NS::LineGeneratorFilter::generateLines()

--- a/LineGenerator/tests/LineGenerator_test.cpp
+++ b/LineGenerator/tests/LineGenerator_test.cpp
@@ -172,7 +172,7 @@ class LineGeneratorFilterTest: public ::testing::Test
 {
 protected:
     // test case type
-    using testCaseType = std::tuple<unsigned int, NS::Sequence,
+    using testCaseType = std::tuple<unsigned int, std::shared_ptr<NS::Sequence>,
                             std::vector<NS::ILineGenerator::Line>>;
 
     void SetUp() override
@@ -188,7 +188,7 @@ protected:
             .push_back(
                 testCaseType(
                     5,
-                    {1, 1},
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1, 1})),
                     {
                         {0, 0, 1, 0, 1},
                         {0, 1, 0, 0, 1},
@@ -203,7 +203,7 @@ protected:
             .push_back(
                 testCaseType(
                     5,
-                    {5},
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({5})),
                     {
                         {1, 1, 1, 1, 1}
                     }
@@ -213,7 +213,7 @@ protected:
             .push_back(
                 testCaseType(
                     5,
-                    {3},
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({3})),
                     {
                         {1, 1, 1, 0, 0},
                         {0, 1, 1, 1, 0},
@@ -225,7 +225,7 @@ protected:
             .push_back(
                 testCaseType(
                     5,
-                    {1},
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1})),
                     {
                         {1, 0, 0, 0, 0},
                         {0, 1, 0, 0, 0},
@@ -239,7 +239,7 @@ protected:
             .push_back(
                 testCaseType(
                     5,
-                    {2},
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({2})),
                     {
                         {1, 1, 0, 0, 0},
                         {0, 1, 1, 0, 0},
@@ -252,7 +252,7 @@ protected:
             .push_back(
                 testCaseType(
                     5,
-                    {4},
+                    std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({4})),
                     {
                         {1, 1, 1, 1, 0},
                         {0, 1, 1, 1, 1}
@@ -268,23 +268,23 @@ protected:
     }
 
     std::vector<testCaseType> testCases;
-    FSTLineSequencer sequencer;
+    std::shared_ptr<FSTLineSequencer> sequencer = std::make_shared<FSTLineSequencer>();
     LineFilterBuilder filterBuilder;
 };
 
 TEST_F(LineGeneratorFilterTest, HandlesSize0)
 {
     EXPECT_EQ(NS::LineGeneratorFilter(
-        filterBuilder.reset().sequenceLineFilter({1}, sequencer).lineFilterInverter().makeLineFilter(),
-        new NS::AllPossibleLinesGenerator(0)).generateLines(),
+        filterBuilder.reset().sequenceLineFilter(std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({1})), sequencer).lineFilterInverter().makeLineFilter(),
+        std::make_unique<NS::AllPossibleLinesGenerator>(0)).generateLines(),
         std::vector<NS::AllPossibleLinesGenerator::Line>());
 }
 
 TEST_F(LineGeneratorFilterTest, HandlesEmptySequence)
 {
     EXPECT_EQ(NS::LineGeneratorFilter(
-        filterBuilder.reset().sequenceLineFilter({0}, sequencer).lineFilterInverter().makeLineFilter(),
-        new NS::AllPossibleLinesGenerator(5)).generateLines(),
+        filterBuilder.reset().sequenceLineFilter(std::make_shared<NS::Sequence>(std::initializer_list<unsigned int>({0})), sequencer).lineFilterInverter().makeLineFilter(),
+        std::make_unique<NS::AllPossibleLinesGenerator>(5)).generateLines(),
         std::vector<NS::AllPossibleLinesGenerator::Line>());
 }
 
@@ -297,7 +297,7 @@ TEST_F(LineGeneratorFilterTest, FiltersLvl1_1)
     for(const auto& testCase : testCases) {
         auto lines = NS::LineGeneratorFilter(
             filterBuilder.reset().sequenceLineFilter(std::get<1>(testCase), sequencer).lineFilterInverter().makeLineFilter(),
-            new NS::AllPossibleLinesGenerator(std::get<0>(testCase))
+            std::make_unique<NS::AllPossibleLinesGenerator>(std::get<0>(testCase))
         ).generateLines();
 
         std::sort(lines.begin(),

--- a/LineSequencer/include/LineSequencer/FSTLineSequencer.hpp
+++ b/LineSequencer/include/LineSequencer/FSTLineSequencer.hpp
@@ -14,7 +14,7 @@ public:
     ~FSTLineSequencer() = default;
 
     // Member methods
-    virtual NS::Sequence operator()(Line line) const;
+    virtual NS::Sequence operator()(const Line& line) const;
 };
 
 #endif /* FSTLINESEQUENCER_H */

--- a/LineSequencer/include/LineSequencer/ILineSequencer.hpp
+++ b/LineSequencer/include/LineSequencer/ILineSequencer.hpp
@@ -17,7 +17,7 @@ public:
     ~ILineSequencer() = default;
 
     // Member methods
-    virtual NS::Sequence operator()(Line line) const = 0;
+    virtual NS::Sequence operator()(const Line& line) const = 0;
 };
 
 #endif /* ILINESEQUENCER_H */

--- a/LineSequencer/src/FSTLineSequencer.cpp
+++ b/LineSequencer/src/FSTLineSequencer.cpp
@@ -3,7 +3,7 @@
 #include <stdexcept>
 #include <sstream>
 
-NS::Sequence FSTLineSequencer::operator()(Line line) const
+NS::Sequence FSTLineSequencer::operator()(const Line& line) const
 {
     // Current state, represent the last value read from the line
     unsigned int state = 0;

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(thread_pool INTERFACE
-            thread-pool/include/BS_thread_pool.hpp)
+            thread-pool/BS_thread_pool.hpp)
 
 target_include_directories(thread_pool INTERFACE
                             thread-pool)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(thread_pool INTERFACE
-            thread-pool/BS_thread_pool.hpp)
+            thread-pool/include/BS_thread_pool.hpp)
 
 target_include_directories(thread_pool INTERFACE
                             thread-pool)


### PR DESCRIPTION
# Features added
- Replaced all raw pointers and references with smart pointers for dependency injections
- Replaced all pass by copy of lines in the () operator of the line filters by pass by reference for performance

# Test performed
1. Invoke Ctest in the build folder
2. Validate tests success

SequenceLineFilterTest.LineFilterBuilder is gonna be solved in a later patch

# Test configuration
## Test hardwarte
- x86-64 machine
- Ryzen 9 5950x
- 32 GB of RAM

## Software
- Linux Mint 21.3
- Kernel 5.15.0-101-generic
- GCC 12.3.0
- CMake 3.22.1